### PR TITLE
Phase 2: 労働市場の精緻化

### DIFF
--- a/src/japan_fiscal_simulator/core/equations/__init__.py
+++ b/src/japan_fiscal_simulator/core/equations/__init__.py
@@ -20,6 +20,10 @@ from japan_fiscal_simulator.core.equations.investment import (
     TobinsQParameters,
 )
 from japan_fiscal_simulator.core.equations.is_curve import ISCurve, ISCurveParameters
+from japan_fiscal_simulator.core.equations.labor_demand import (
+    LaborDemand,
+    LaborDemandParameters,
+)
 from japan_fiscal_simulator.core.equations.phillips_curve import (
     PhillipsCurve,
     PhillipsCurveParameters,
@@ -29,6 +33,11 @@ from japan_fiscal_simulator.core.equations.taylor_rule import (
     TaylorRule,
     TaylorRuleParameters,
     check_taylor_principle,
+)
+from japan_fiscal_simulator.core.equations.wage_phillips import (
+    WagePhillipsCurve,
+    WagePhillipsCurveParameters,
+    compute_wage_adjustment_speed,
 )
 
 __all__ = [
@@ -42,6 +51,8 @@ __all__ = [
     "ISCurveParameters",
     "InvestmentAdjustmentEquation",
     "InvestmentAdjustmentParameters",
+    "LaborDemand",
+    "LaborDemandParameters",
     "PhillipsCurve",
     "PhillipsCurveParameters",
     "TaylorRule",
@@ -49,6 +60,9 @@ __all__ = [
     "TechnologyProcess",
     "TobinsQEquation",
     "TobinsQParameters",
+    "WagePhillipsCurve",
+    "WagePhillipsCurveParameters",
     "check_taylor_principle",
     "compute_phillips_slope",
+    "compute_wage_adjustment_speed",
 ]

--- a/src/japan_fiscal_simulator/core/equations/base.py
+++ b/src/japan_fiscal_simulator/core/equations/base.py
@@ -28,6 +28,7 @@ class EquationCoefficients:
     i_forward: float = 0.0
     q_forward: float = 0.0
     rk_forward: float = 0.0
+    w_forward: float = 0.0  # Phase 2: 賃金
 
     # 当期（t期）の係数 (B行列への寄与)
     y_current: float = 0.0
@@ -39,6 +40,9 @@ class EquationCoefficients:
     i_current: float = 0.0
     q_current: float = 0.0
     rk_current: float = 0.0
+    w_current: float = 0.0  # Phase 2: 賃金
+    n_current: float = 0.0  # Phase 2: 労働
+    c_current: float = 0.0  # Phase 2: 消費（MRS用）
 
     # 前期（t-1期）の係数 (C行列への寄与)
     y_lag: float = 0.0
@@ -50,12 +54,15 @@ class EquationCoefficients:
     i_lag: float = 0.0
     q_lag: float = 0.0
     rk_lag: float = 0.0
+    w_lag: float = 0.0  # Phase 2: 賃金
+    c_lag: float = 0.0  # Phase 2: 消費（習慣形成用）
 
     # ショック係数 (D行列への寄与)
     e_g: float = 0.0
     e_a: float = 0.0
     e_m: float = 0.0
     e_i: float = 0.0
+    e_w: float = 0.0  # Phase 2: 賃金マークアップショック
 
 
 class Equation(Protocol):

--- a/src/japan_fiscal_simulator/core/equations/is_curve.py
+++ b/src/japan_fiscal_simulator/core/equations/is_curve.py
@@ -1,9 +1,15 @@
 """IS曲線（動学的IS方程式）
 
+習慣形成なし（h=0）:
 y_t = E[y_{t+1}] - σ^{-1}(r_t - E[π_{t+1}]) + g_y·g_t + a_t
 
-標準化形式（=0）:
-y_t - E[y_{t+1}] + σ^{-1}·r_t - σ^{-1}·E[π_{t+1}] - g_y·g_t - a_t = 0
+習慣形成あり（h>0）:
+y_t = h·y_{t-1} + (1-h)·E[y_{t+1}] - σ_h^{-1}(r_t - E[π_{t+1}]) + g_y·g_t + a_t
+
+ここで σ_h = σ·(1-h)/(1+h) は習慣形成調整後の異時点間代替弾力性の逆数
+
+標準化形式（=0、習慣形成あり）:
+y_t - h·y_{t-1} - (1-h)·E[y_{t+1}] + σ_h^{-1}·r_t - σ_h^{-1}·E[π_{t+1}] - g_y·g_t - a_t = 0
 """
 
 from dataclasses import dataclass
@@ -17,6 +23,7 @@ class ISCurveParameters:
 
     sigma: float  # 異時点間代替弾力性の逆数
     g_y: float  # 政府支出/GDP比率（政府支出の効果係数）
+    habit: float = 0.0  # 習慣形成パラメータ（0-1）
 
 
 class ISCurve:
@@ -24,6 +31,9 @@ class ISCurve:
 
     消費のオイラー方程式から導出される動学的IS曲線。
     産出ギャップが実質金利と期待産出に依存する。
+
+    習慣形成（habit > 0）の場合、消費が前期の消費にも依存し、
+    消費応答がハンプ型（hump-shaped）になる。
     """
 
     def __init__(self, params: ISCurveParameters) -> None:
@@ -35,22 +45,47 @@ class ISCurve:
 
     @property
     def description(self) -> str:
+        if self.params.habit > 0:
+            return (
+                "y_t = h·y_{t-1} + (1-h)·E[y_{t+1}] "
+                "- σ_h^{-1}(r_t - E[π_{t+1}]) + g_y·g_t + a_t"
+            )
         return "y_t = E[y_{t+1}] - σ^{-1}(r_t - E[π_{t+1}]) + g_y·g_t + a_t"
 
     def coefficients(self) -> EquationCoefficients:
         """IS曲線の係数を返す
 
+        習慣形成なし:
         y_t - E[y_{t+1}] + σ^{-1}·r_t - σ^{-1}·E[π_{t+1}] - g_y·g_t - a_t = 0
+
+        習慣形成あり:
+        y_t - h·y_{t-1} - (1-h)·E[y_{t+1}] + σ_h^{-1}·r_t - σ_h^{-1}·E[π_{t+1}]
+            - g_y·g_t - a_t = 0
         """
-        sigma_inv = 1.0 / self.params.sigma
+        h = self.params.habit
+        sigma = self.params.sigma
+
+        if h > 0:
+            # 習慣形成あり: σ_h = σ·(1-h)/(1+h)
+            sigma_h = sigma * (1 - h) / (1 + h)
+            sigma_inv = 1.0 / sigma_h
+            y_forward_coef = -(1 - h)
+            y_lag_coef = -h
+        else:
+            # 習慣形成なし（従来）
+            sigma_inv = 1.0 / sigma
+            y_forward_coef = -1.0
+            y_lag_coef = 0.0
 
         return EquationCoefficients(
             # 期待値（t+1期）
-            y_forward=-1.0,
+            y_forward=y_forward_coef,
             pi_forward=-sigma_inv,
             # 当期（t期）
             y_current=1.0,
             r_current=sigma_inv,
             g_current=-self.params.g_y,
             a_current=-1.0,
+            # 前期（t-1期）
+            y_lag=y_lag_coef,
         )

--- a/src/japan_fiscal_simulator/core/equations/labor_demand.py
+++ b/src/japan_fiscal_simulator/core/equations/labor_demand.py
@@ -1,0 +1,56 @@
+"""労働需要方程式
+
+生産関数 Y = A × K^α × N^(1-α) から導出される労働需要。
+
+対数線形化:
+n̂_t = (1/(1-α))·(ŷ_t - â_t) - (α/(1-α))·k̂_{t-1}
+
+標準化形式（=0）:
+n̂_t - (1/(1-α))·ŷ_t + (1/(1-α))·â_t + (α/(1-α))·k̂_{t-1} = 0
+"""
+
+from dataclasses import dataclass
+
+from japan_fiscal_simulator.core.equations.base import EquationCoefficients
+
+
+@dataclass(frozen=True)
+class LaborDemandParameters:
+    """労働需要のパラメータ"""
+
+    alpha: float  # 資本分配率
+
+
+class LaborDemand:
+    """労働需要方程式
+
+    コブ・ダグラス生産関数から導出される労働需要。
+    生産量と技術水準、資本ストックから労働投入を決定。
+    """
+
+    def __init__(self, params: LaborDemandParameters) -> None:
+        self.params = params
+
+    @property
+    def name(self) -> str:
+        return "Labor Demand"
+
+    @property
+    def description(self) -> str:
+        return "n̂_t = (1/(1-α))·(ŷ_t - â_t) - (α/(1-α))·k̂_{t-1}"
+
+    def coefficients(self) -> EquationCoefficients:
+        """労働需要方程式の係数を返す
+
+        標準化形式:
+        n̂_t - (1/(1-α))·ŷ_t + (1/(1-α))·â_t + (α/(1-α))·k̂_{t-1} = 0
+        """
+        alpha = self.params.alpha
+        labor_share = 1 - alpha
+
+        return EquationCoefficients(
+            n_current=1.0,
+            y_current=-1.0 / labor_share,
+            a_current=1.0 / labor_share,
+            k_lag=alpha / labor_share,
+        )

--- a/src/japan_fiscal_simulator/core/equations/wage_phillips.py
+++ b/src/japan_fiscal_simulator/core/equations/wage_phillips.py
@@ -1,0 +1,105 @@
+"""賃金のNew Keynesian Phillips Curve
+
+Calvo型賃金硬直性に基づく賃金動学。MRS（限界代替率）を代入済み。
+
+ŵ_t = (β/(1+β))E[ŵ_{t+1}] + (1/(1+β))ŵ_{t-1}
+    + (λ_w/(1+β))(σ·ĉ_t + φ·n̂_t - ŵ_t) + e_w,t
+
+ここで:
+- λ_w = (1-θ_w)(1-β·θ_w)/θ_w（賃金調整速度）
+- mrs_t = σ·ĉ_t + φ·n̂_t（限界代替率）
+
+標準化形式（=0）:
+(1 + λ_w/(1+β))·ŵ_t - (β/(1+β))·E[ŵ_{t+1}] - (1/(1+β))·ŵ_{t-1}
+    - (λ_w·σ/(1+β))·ĉ_t - (λ_w·φ/(1+β))·n̂_t - e_w,t = 0
+"""
+
+from dataclasses import dataclass
+
+from japan_fiscal_simulator.core.equations.base import EquationCoefficients
+
+
+@dataclass(frozen=True)
+class WagePhillipsCurveParameters:
+    """賃金NKPCのパラメータ"""
+
+    beta: float  # 割引率
+    theta_w: float  # Calvo賃金硬直性（賃金を変更しない確率）
+    sigma: float  # 異時点間代替弾力性の逆数
+    phi: float  # 労働供給弾力性の逆数（Frisch弾力性）
+
+
+def compute_wage_adjustment_speed(beta: float, theta_w: float) -> float:
+    """賃金調整速度 λ_w を計算
+
+    λ_w = (1-θ_w)(1-β·θ_w)/θ_w
+
+    価格のPhillips曲線スロープ κ と同様の構造。
+    θ_wが高いほど（賃金硬直性が高いほど）λ_wは小さくなる。
+
+    Args:
+        beta: 割引率
+        theta_w: Calvo賃金硬直性
+
+    Returns:
+        賃金調整速度 λ_w
+    """
+    return (1 - theta_w) * (1 - beta * theta_w) / theta_w
+
+
+class WagePhillipsCurve:
+    """賃金のNew Keynesian Phillips Curve
+
+    Calvo型賃金設定から導出される前向き・後向き賃金動学。
+    MRSを代入済みの形式で、消費と労働に直接依存。
+    """
+
+    def __init__(self, params: WagePhillipsCurveParameters) -> None:
+        self.params = params
+        self._lambda_w = compute_wage_adjustment_speed(params.beta, params.theta_w)
+
+    @property
+    def name(self) -> str:
+        return "Wage Phillips Curve"
+
+    @property
+    def description(self) -> str:
+        return (
+            "ŵ_t = (β/(1+β))E[ŵ_{t+1}] + (1/(1+β))ŵ_{t-1} "
+            "+ (λ_w/(1+β))(mrs_t - ŵ_t) + e_w,t"
+        )
+
+    @property
+    def lambda_w(self) -> float:
+        """賃金調整速度"""
+        return self._lambda_w
+
+    def coefficients(self) -> EquationCoefficients:
+        """賃金NKPCの係数を返す
+
+        標準化形式:
+        (1 + λ_w/(1+β))·ŵ_t - (β/(1+β))·E[ŵ_{t+1}] - (1/(1+β))·ŵ_{t-1}
+            - (λ_w·σ/(1+β))·ĉ_t - (λ_w·φ/(1+β))·n̂_t - e_w,t = 0
+        """
+        beta = self.params.beta
+        sigma = self.params.sigma
+        phi = self.params.phi
+        lambda_w = self._lambda_w
+
+        denom = 1 + beta
+
+        # 係数計算
+        w_current_coef = 1.0 + lambda_w / denom
+        w_forward_coef = -beta / denom
+        w_lag_coef = -1.0 / denom
+        c_current_coef = -lambda_w * sigma / denom
+        n_current_coef = -lambda_w * phi / denom
+
+        return EquationCoefficients(
+            w_current=w_current_coef,
+            w_forward=w_forward_coef,
+            w_lag=w_lag_coef,
+            c_current=c_current_coef,
+            n_current=n_current_coef,
+            e_w=-1.0,
+        )

--- a/src/japan_fiscal_simulator/parameters/defaults.py
+++ b/src/japan_fiscal_simulator/parameters/defaults.py
@@ -75,6 +75,21 @@ class InvestmentParameters:
 
 
 @dataclass(frozen=True)
+class LaborParameters:
+    """労働市場パラメータ
+
+    参考文献:
+    - Smets & Wouters (2007): θ_w ≈ 0.73, ε_w ≈ 10
+    - Erceg, Henderson & Levin (2000): 賃金Phillips曲線
+    - Sugo & Ueda (2008, 日本): θ_w ≈ 0.70
+    """
+
+    theta_w: float = 0.75  # Calvo賃金硬直性（75%が賃金維持）
+    epsilon_w: float = 10.0  # 労働の代替弾力性
+    iota_w: float = 0.5  # 賃金インデクセーション（0=後向き、1=前向き）
+
+
+@dataclass(frozen=True)
 class ShockParameters:
     """ショックパラメータ"""
 
@@ -86,6 +101,8 @@ class ShockParameters:
     rho_risk: float = 0.75  # リスクプレミアムショック
     # 投資固有技術ショック: Smets-Wouters (2007) では ρ_i ≈ 0.71
     rho_i: float = 0.70
+    # 賃金マークアップショック: Smets-Wouters (2007) では ρ_w ≈ 0.89
+    rho_w: float = 0.90
 
     # 標準偏差
     sigma_a: float = 0.01
@@ -94,6 +111,7 @@ class ShockParameters:
     sigma_m: float = 0.0025
     sigma_risk: float = 0.01
     sigma_i: float = 0.01
+    sigma_w: float = 0.01  # 賃金マークアップショック
 
 
 @dataclass
@@ -106,6 +124,7 @@ class DefaultParameters:
     central_bank: CentralBankParameters = field(default_factory=CentralBankParameters)
     financial: FinancialParameters = field(default_factory=FinancialParameters)
     investment: InvestmentParameters = field(default_factory=InvestmentParameters)
+    labor: LaborParameters = field(default_factory=LaborParameters)
     shocks: ShockParameters = field(default_factory=ShockParameters)
 
     def with_updates(
@@ -116,6 +135,7 @@ class DefaultParameters:
         central_bank: CentralBankParameters | None = None,
         financial: FinancialParameters | None = None,
         investment: InvestmentParameters | None = None,
+        labor: LaborParameters | None = None,
         shocks: ShockParameters | None = None,
     ) -> Self:
         """パラメータの一部を更新した新しいインスタンスを返す"""
@@ -127,6 +147,7 @@ class DefaultParameters:
             central_bank=central_bank if central_bank is not None else self.central_bank,
             financial=financial if financial is not None else self.financial,
             investment=investment if investment is not None else self.investment,
+            labor=labor if labor is not None else self.labor,
             shocks=shocks if shocks is not None else self.shocks,
         )
 

--- a/tests/test_capital_investment.py
+++ b/tests/test_capital_investment.py
@@ -138,31 +138,34 @@ class TestCapitalRentalRate:
 
 
 class TestNewKeynesianModelExpanded:
-    """拡張NKモデル（9方程式）のテスト"""
+    """拡張NKモデル（11方程式）のテスト"""
 
     def test_model_variables(self) -> None:
         """モデル変数が正しく設定されていることを確認"""
         params = DefaultParameters()
         model = NewKeynesianModel(params)
 
-        # 状態変数: g, a, k, i
-        assert model.vars.n_state == 4
+        # 状態変数: g, a, k, i, w (Phase 2で拡張)
+        assert model.vars.n_state == 5
         assert "g" in model.vars.state_vars
         assert "a" in model.vars.state_vars
         assert "k" in model.vars.state_vars
         assert "i" in model.vars.state_vars
+        assert "w" in model.vars.state_vars  # Phase 2
 
-        # 制御変数: y, pi, r, q, rk
-        assert model.vars.n_control == 5
+        # 制御変数: y, pi, r, q, rk, n (Phase 2で拡張)
+        assert model.vars.n_control == 6
         assert "y" in model.vars.control_vars
         assert "pi" in model.vars.control_vars
         assert "r" in model.vars.control_vars
         assert "q" in model.vars.control_vars
         assert "rk" in model.vars.control_vars
+        assert "n" in model.vars.control_vars  # Phase 2
 
-        # ショック: e_g, e_a, e_m, e_i
-        assert model.vars.n_shock == 4
+        # ショック: e_g, e_a, e_m, e_i, e_w (Phase 2で拡張)
+        assert model.vars.n_shock == 5
         assert "e_i" in model.vars.shocks
+        assert "e_w" in model.vars.shocks  # Phase 2
 
     def test_solution_matrices_shape(self) -> None:
         """解行列の形状が正しいことを確認"""
@@ -170,14 +173,14 @@ class TestNewKeynesianModelExpanded:
         model = NewKeynesianModel(params)
         sol = model.solution
 
-        # P: (4 x 4) 状態遷移
-        assert sol.P.shape == (4, 4)
-        # Q: (4 x 4) ショック応答
-        assert sol.Q.shape == (4, 4)
-        # R: (5 x 4) 制御の状態依存
-        assert sol.R.shape == (5, 4)
-        # S: (5 x 4) 制御へのショック直接効果
-        assert sol.S.shape == (5, 4)
+        # P: (5 x 5) 状態遷移 (Phase 2で拡張)
+        assert sol.P.shape == (5, 5)
+        # Q: (5 x 5) ショック応答 (Phase 2で拡張)
+        assert sol.Q.shape == (5, 5)
+        # R: (6 x 5) 制御の状態依存 (Phase 2で拡張)
+        assert sol.R.shape == (6, 5)
+        # S: (6 x 5) 制御へのショック直接効果 (Phase 2で拡張)
+        assert sol.S.shape == (6, 5)
 
     def test_state_persistence(self) -> None:
         """状態変数の持続性が正しいことを確認"""

--- a/tests/test_golden_master.py
+++ b/tests/test_golden_master.py
@@ -27,13 +27,14 @@ class TestNKModelGoldenMaster:
         sol = nk_model.solution
         P = sol.P
 
-        # 9方程式モデル: 状態変数 [g, a, k, i]
-        assert P.shape == (4, 4)
+        # 11方程式モデル (Phase 2): 状態変数 [g, a, k, i, w]
+        assert P.shape == (5, 5)
         # P の対角成分は持続性パラメータ
         np.testing.assert_allclose(P[0, 0], 0.9, rtol=1e-10)  # rho_g
         np.testing.assert_allclose(P[1, 1], 0.9, rtol=1e-10)  # rho_a
         np.testing.assert_allclose(P[2, 2], 1 - 0.025, rtol=1e-10)  # 1 - delta
         np.testing.assert_allclose(P[3, 3], 0.70, rtol=1e-10)  # rho_i
+        np.testing.assert_allclose(P[4, 4], 0.90, rtol=1e-10)  # rho_w (Phase 2)
         # 資本蓄積: k <- i
         np.testing.assert_allclose(P[2, 3], 0.025, rtol=1e-10)  # delta
 
@@ -42,12 +43,13 @@ class TestNKModelGoldenMaster:
         sol = nk_model.solution
         Q = sol.Q
 
-        # 9方程式モデル: ショック [e_g, e_a, e_m, e_i]
-        assert Q.shape == (4, 4)
+        # 11方程式モデル (Phase 2): ショック [e_g, e_a, e_m, e_i, e_w]
+        assert Q.shape == (5, 5)
         # Q[0, 0] = 1 (e_g -> g), Q[1, 1] = 1 (e_a -> a), Q[3, 3] = 1 (e_i -> i)
         np.testing.assert_allclose(Q[0, 0], 1.0, rtol=1e-10)
         np.testing.assert_allclose(Q[1, 1], 1.0, rtol=1e-10)
         np.testing.assert_allclose(Q[3, 3], 1.0, rtol=1e-10)
+        np.testing.assert_allclose(Q[4, 4], 1.0, rtol=1e-10)  # e_w -> w (Phase 2)
         # e_m は状態に影響しない
         np.testing.assert_allclose(Q[0, 2], 0.0, rtol=1e-10)
         np.testing.assert_allclose(Q[1, 2], 0.0, rtol=1e-10)
@@ -57,8 +59,8 @@ class TestNKModelGoldenMaster:
         sol = nk_model.solution
         R = sol.R
 
-        # 9方程式モデル: 制御変数 [y, π, r, q, rk] x 状態 [g, a, k, i]
-        assert R.shape == (5, 4)
+        # 11方程式モデル (Phase 2): 制御変数 [y, π, r, q, rk, n] x 状態 [g, a, k, i, w]
+        assert R.shape == (6, 5)
         # R[0, 0] = psi_yg (y の g への応答)
         # 値は正であるべき（政府支出は産出を増加させる）
         assert R[0, 0] > 0  # psi_yg
@@ -72,8 +74,8 @@ class TestNKModelGoldenMaster:
         sol = nk_model.solution
         S = sol.S
 
-        # 9方程式モデル: 制御変数 [y, π, r, q, rk] x ショック [e_g, e_a, e_m, e_i]
-        assert S.shape == (5, 4)
+        # 11方程式モデル (Phase 2): 制御変数 [y, π, r, q, rk, n] x ショック [e_g, e_a, e_m, e_i, e_w]
+        assert S.shape == (6, 5)
         # 金融引き締め(e_m > 0)は産出を減少させる
         assert S[0, 2] < 0  # psi_ym < 0
         # 状態に影響するショック(e_g, e_a, e_i)はSではなくQで効果を持つ

--- a/tests/test_habit_formation.py
+++ b/tests/test_habit_formation.py
@@ -1,0 +1,148 @@
+"""習慣形成のテスト (Phase 2)"""
+
+import pytest
+
+from japan_fiscal_simulator.core.equations.is_curve import ISCurve, ISCurveParameters
+from japan_fiscal_simulator.core.nk_model import NewKeynesianModel
+from japan_fiscal_simulator.parameters.defaults import DefaultParameters, HouseholdParameters
+
+
+class TestISCurveWithHabit:
+    """習慣形成付きIS曲線のテスト"""
+
+    def test_no_habit_coefficients(self) -> None:
+        """習慣形成なし（h=0）の係数テスト"""
+        params = ISCurveParameters(sigma=1.5, g_y=0.2, habit=0.0)
+        eq = ISCurve(params)
+        coef = eq.coefficients()
+
+        # 習慣形成なしの係数
+        assert coef.y_current == 1.0
+        assert coef.y_forward == -1.0
+        assert coef.y_lag == 0.0  # ラグ項なし
+        assert coef.r_current == pytest.approx(1.0 / 1.5)
+        assert coef.pi_forward == pytest.approx(-1.0 / 1.5)
+
+    def test_with_habit_coefficients(self) -> None:
+        """習慣形成あり（h=0.7）の係数テスト"""
+        h = 0.7
+        sigma = 1.5
+        params = ISCurveParameters(sigma=sigma, g_y=0.2, habit=h)
+        eq = ISCurve(params)
+        coef = eq.coefficients()
+
+        # 習慣形成調整後の sigma
+        sigma_h = sigma * (1 - h) / (1 + h)
+        sigma_h_inv = 1.0 / sigma_h
+
+        # 係数を確認
+        assert coef.y_current == 1.0
+        assert coef.y_forward == pytest.approx(-(1 - h))
+        assert coef.y_lag == pytest.approx(-h)
+        assert coef.r_current == pytest.approx(sigma_h_inv)
+        assert coef.pi_forward == pytest.approx(-sigma_h_inv)
+
+    def test_habit_increases_interest_rate_sensitivity(self) -> None:
+        """習慣形成により金利感応度が上昇"""
+        sigma = 1.5
+        g_y = 0.2
+
+        # 習慣形成なし
+        eq_no_habit = ISCurve(ISCurveParameters(sigma=sigma, g_y=g_y, habit=0.0))
+        coef_no = eq_no_habit.coefficients()
+
+        # 習慣形成あり
+        eq_habit = ISCurve(ISCurveParameters(sigma=sigma, g_y=g_y, habit=0.7))
+        coef_habit = eq_habit.coefficients()
+
+        # σ_h = σ(1-h)/(1+h) < σ なので 1/σ_h > 1/σ
+        # つまり r_current の絶対値が大きくなる
+        assert abs(coef_habit.r_current) > abs(coef_no.r_current)
+
+    def test_habit_zero_recovers_standard(self) -> None:
+        """h=0で標準的なIS曲線に戻る"""
+        params_zero = ISCurveParameters(sigma=1.5, g_y=0.2, habit=0.0)
+        params_small = ISCurveParameters(sigma=1.5, g_y=0.2, habit=0.001)
+
+        eq_zero = ISCurve(params_zero)
+        eq_small = ISCurve(params_small)
+
+        coef_zero = eq_zero.coefficients()
+        coef_small = eq_small.coefficients()
+
+        # 非常に小さい habit では標準に近い
+        assert coef_small.y_forward == pytest.approx(coef_zero.y_forward, rel=0.01)
+        # ただし y_lag は 0 にはならない
+        assert coef_small.y_lag != 0.0
+
+    def test_description_changes_with_habit(self) -> None:
+        """習慣形成の有無で説明が変わる"""
+        eq_no = ISCurve(ISCurveParameters(sigma=1.5, g_y=0.2, habit=0.0))
+        eq_yes = ISCurve(ISCurveParameters(sigma=1.5, g_y=0.2, habit=0.7))
+
+        # 習慣形成ありの説明には h または y_{t-1} が含まれる
+        assert "h" in eq_yes.description or "y_{t-1}" in eq_yes.description
+        # 習慣形成なしの説明には含まれない（標準的なIS曲線）
+        assert "h·" not in eq_no.description
+
+    def test_extreme_habit(self) -> None:
+        """極端な習慣形成パラメータのテスト"""
+        # h に近い値
+        params = ISCurveParameters(sigma=1.5, g_y=0.2, habit=0.95)
+        eq = ISCurve(params)
+        coef = eq.coefficients()
+
+        # y_lag が大きくなる
+        assert abs(coef.y_lag) > 0.9
+        # y_forward が小さくなる
+        assert abs(coef.y_forward) < 0.1
+
+    def test_habit_sum_property(self) -> None:
+        """y_forward + y_lag の関係"""
+        h = 0.7
+        params = ISCurveParameters(sigma=1.5, g_y=0.2, habit=h)
+        eq = ISCurve(params)
+        coef = eq.coefficients()
+
+        # y_forward = -(1-h), y_lag = -h
+        # y_forward + y_lag = -(1-h) - h = -1
+        assert coef.y_forward + coef.y_lag == pytest.approx(-1.0)
+
+
+class TestHabitFormationIntegration:
+    """習慣形成の統合テスト"""
+
+    def test_default_habit_parameter(self) -> None:
+        """デフォルトの習慣形成パラメータ"""
+        params = DefaultParameters()
+        # HouseholdParameters に habit が存在
+        assert hasattr(params.household, "habit")
+        assert params.household.habit == 0.7
+
+    def test_is_curve_uses_habit(self) -> None:
+        """IS曲線が習慣形成を使用することを確認"""
+        # 習慣形成あり
+        params_habit = DefaultParameters()
+
+        # 習慣形成なし
+        params_no_habit = DefaultParameters().with_updates(
+            household=HouseholdParameters(
+                beta=params_habit.household.beta,
+                sigma=params_habit.household.sigma,
+                phi=params_habit.household.phi,
+                habit=0.0,
+                chi=params_habit.household.chi,
+            )
+        )
+
+        model_habit = NewKeynesianModel(params_habit)
+        model_no_habit = NewKeynesianModel(params_no_habit)
+
+        # 解が異なることを確認（習慣形成の効果）
+        sol_habit = model_habit.solution
+        sol_no_habit = model_no_habit.solution
+
+        # P行列（状態遷移）が異なる可能性がある
+        # ただし現在の縮約形解法では直接的な影響は限定的
+        # 将来のBK解法で完全に反映される
+        assert sol_habit.kappa == sol_no_habit.kappa  # Phillips曲線スロープは同じ

--- a/tests/test_labor_market.py
+++ b/tests/test_labor_market.py
@@ -1,0 +1,205 @@
+"""労働市場方程式のテスト (Phase 2)"""
+
+import pytest
+
+from japan_fiscal_simulator.core.equations.labor_demand import (
+    LaborDemand,
+    LaborDemandParameters,
+)
+from japan_fiscal_simulator.core.equations.wage_phillips import (
+    WagePhillipsCurve,
+    WagePhillipsCurveParameters,
+    compute_wage_adjustment_speed,
+)
+from japan_fiscal_simulator.parameters.defaults import (
+    DefaultParameters,
+    LaborParameters,
+)
+
+
+class TestWageAdjustmentSpeed:
+    """賃金調整速度 λ_w のテスト"""
+
+    def test_compute_basic(self) -> None:
+        """基本的な計算のテスト"""
+        beta = 0.99
+        theta_w = 0.75
+        lambda_w = compute_wage_adjustment_speed(beta, theta_w)
+
+        # λ_w = (1-0.75)(1-0.99*0.75)/0.75 = 0.25 * 0.2575 / 0.75 ≈ 0.086
+        expected = (1 - 0.75) * (1 - 0.99 * 0.75) / 0.75
+        assert lambda_w == pytest.approx(expected)
+
+    def test_high_rigidity(self) -> None:
+        """高硬直性（θ_w=0.9）で調整速度が低下"""
+        beta = 0.99
+        theta_w_high = 0.90
+        theta_w_low = 0.50
+
+        lambda_w_high = compute_wage_adjustment_speed(beta, theta_w_high)
+        lambda_w_low = compute_wage_adjustment_speed(beta, theta_w_low)
+
+        # 高硬直性 → 低調整速度
+        assert lambda_w_high < lambda_w_low
+
+    def test_limiting_cases(self) -> None:
+        """極限ケースのテスト"""
+        beta = 0.99
+
+        # θ_w が小さいほど λ_w は大きい
+        lambda_w_flex = compute_wage_adjustment_speed(beta, 0.1)
+        lambda_w_rigid = compute_wage_adjustment_speed(beta, 0.9)
+
+        assert lambda_w_flex > lambda_w_rigid
+
+
+class TestWagePhillipsCurve:
+    """賃金NKPCのテスト"""
+
+    def test_coefficients_basic(self) -> None:
+        """基本的な係数のテスト"""
+        params = WagePhillipsCurveParameters(
+            beta=0.99,
+            theta_w=0.75,
+            sigma=1.5,
+            phi=2.0,
+        )
+        eq = WagePhillipsCurve(params)
+        coef = eq.coefficients()
+
+        # w_current > 0（左辺）
+        assert coef.w_current > 0
+        # w_forward < 0（前向き期待）
+        assert coef.w_forward < 0
+        # w_lag < 0（後向きインデクセーション）
+        assert coef.w_lag < 0
+        # c_current < 0（MRSの消費項）
+        assert coef.c_current < 0
+        # n_current < 0（MRSの労働項）
+        assert coef.n_current < 0
+        # e_w = -1（ショック）
+        assert coef.e_w == -1.0
+
+    def test_coefficient_sum(self) -> None:
+        """係数の整合性テスト"""
+        params = WagePhillipsCurveParameters(
+            beta=0.99,
+            theta_w=0.75,
+            sigma=1.5,
+            phi=2.0,
+        )
+        eq = WagePhillipsCurve(params)
+        coef = eq.coefficients()
+
+        # w_current + w_forward + w_lag の関係をチェック
+        # 定常状態では w_t = w_{t-1} = E[w_{t+1}] なので
+        # w_current + w_forward + w_lag + λ_w/(1+β) = 0 に近くなる
+        denom = 1 + params.beta
+        lambda_w = eq.lambda_w
+        expected_w_sum = 1 + lambda_w / denom - params.beta / denom - 1 / denom
+        assert coef.w_current + coef.w_forward + coef.w_lag == pytest.approx(
+            expected_w_sum
+        )
+
+    def test_name_and_description(self) -> None:
+        """名前と説明のテスト"""
+        params = WagePhillipsCurveParameters(
+            beta=0.99, theta_w=0.75, sigma=1.5, phi=2.0
+        )
+        eq = WagePhillipsCurve(params)
+
+        assert "Wage" in eq.name
+        assert "ŵ_t" in eq.description or "w_t" in eq.description
+
+    def test_lambda_w_property(self) -> None:
+        """λ_w プロパティのテスト"""
+        params = WagePhillipsCurveParameters(
+            beta=0.99, theta_w=0.75, sigma=1.5, phi=2.0
+        )
+        eq = WagePhillipsCurve(params)
+
+        expected = compute_wage_adjustment_speed(0.99, 0.75)
+        assert eq.lambda_w == pytest.approx(expected)
+
+
+class TestLaborDemand:
+    """労働需要方程式のテスト"""
+
+    def test_coefficients_basic(self) -> None:
+        """基本的な係数のテスト"""
+        params = LaborDemandParameters(alpha=0.33)
+        eq = LaborDemand(params)
+        coef = eq.coefficients()
+
+        labor_share = 1 - 0.33
+
+        # n_current = 1
+        assert coef.n_current == 1.0
+        # y_current = -1/(1-α)
+        assert coef.y_current == pytest.approx(-1.0 / labor_share)
+        # a_current = 1/(1-α)
+        assert coef.a_current == pytest.approx(1.0 / labor_share)
+        # k_lag = α/(1-α)
+        assert coef.k_lag == pytest.approx(0.33 / labor_share)
+
+    def test_labor_share_effect(self) -> None:
+        """労働シェアの効果テスト"""
+        # α=0.25（労働シェア高 = 0.75）
+        params_high = LaborDemandParameters(alpha=0.25)
+        eq_high = LaborDemand(params_high)
+        coef_high = eq_high.coefficients()
+
+        # α=0.40（労働シェア低 = 0.60）
+        params_low = LaborDemandParameters(alpha=0.40)
+        eq_low = LaborDemand(params_low)
+        coef_low = eq_low.coefficients()
+
+        # 労働シェアが低いほど y_current の絶対値が大きい
+        assert abs(coef_low.y_current) > abs(coef_high.y_current)
+
+    def test_name_and_description(self) -> None:
+        """名前と説明のテスト"""
+        params = LaborDemandParameters(alpha=0.33)
+        eq = LaborDemand(params)
+
+        assert "Labor" in eq.name
+        assert "n̂_t" in eq.description or "n_t" in eq.description
+
+
+class TestLaborParameters:
+    """労働パラメータのテスト"""
+
+    def test_default_parameters(self) -> None:
+        """デフォルトパラメータが設定されていることを確認"""
+        params = DefaultParameters()
+
+        assert hasattr(params, "labor")
+        assert params.labor.theta_w == 0.75
+        assert params.labor.epsilon_w == 10.0
+        assert params.labor.iota_w == 0.5
+
+    def test_labor_parameters_immutable(self) -> None:
+        """LaborParametersが不変であることを確認"""
+        params = LaborParameters()
+
+        with pytest.raises(AttributeError):
+            params.theta_w = 0.5  # type: ignore[misc]
+
+    def test_shock_parameters(self) -> None:
+        """ショックパラメータに賃金マークアップが追加されていることを確認"""
+        params = DefaultParameters()
+
+        assert hasattr(params.shocks, "rho_w")
+        assert hasattr(params.shocks, "sigma_w")
+        assert params.shocks.rho_w == 0.90
+        assert params.shocks.sigma_w == 0.01
+
+    def test_with_updates_labor(self) -> None:
+        """with_updatesでlaborパラメータを更新できることを確認"""
+        params = DefaultParameters()
+        new_labor = LaborParameters(theta_w=0.70)
+        updated = params.with_updates(labor=new_labor)
+
+        assert updated.labor.theta_w == 0.70
+        # 他のパラメータは変更されていない
+        assert updated.household.beta == params.household.beta


### PR DESCRIPTION
## 概要

ロードマップPhase 2として、Calvo型賃金硬直性と労働供給を明示的にモデル化し、NKモデルを9方程式から11方程式体系へ拡張しました。

## 追加した方程式

### 賃金のNKPC（MRS代入済み）
```
ŵ_t = (β/(1+β))E[ŵ_{t+1}] + (1/(1+β))ŵ_{t-1}
    + (λ_w/(1+β))(σ·ĉ_t + φ·n̂_t - ŵ_t) + e_w,t
```

### 労働需要（生産関数から導出）
```
n̂_t = (1/(1-α))(ŷ_t - â_t) - (α/(1-α))k̂_{t-1}
```

### 習慣形成付きIS曲線（既存を修正）
```
ŷ_t = h·ŷ_{t-1} + (1-h)E[ŷ_{t+1}] - σ_h^{-1}(r_t - E[π_{t+1}]) + g_y·g_t + a_t
```

## 変更内容

### 新規ファイル
- `core/equations/wage_phillips.py`: 賃金NKPC
- `core/equations/labor_demand.py`: 労働需要
- `tests/test_labor_market.py`: 労働市場テスト
- `tests/test_habit_formation.py`: 習慣形成テスト

### 修正ファイル
- `parameters/defaults.py`: LaborParameters追加、ShockParametersにrho_w/sigma_w追加
- `core/equations/base.py`: w, n, c, e_wフィールド追加
- `core/equations/is_curve.py`: 習慣形成対応
- `core/nk_model.py`: 11方程式体系（状態5、制御6、ショック5）に拡張

## モデル変数

| 区分 | 変数 |
|------|------|
| 状態変数 | g, a, k, i, **w** (5個) |
| 制御変数 | y, π, r, q, rk, **n** (6個) |
| ショック | e_g, e_a, e_m, e_i, **e_w** (5個) |

## テスト計画

- [x] 単体テスト: 賃金調整速度λ_w、方程式係数
- [x] 統合テスト: NKモデルの解の存在確認
- [x] 後方互換性: Phase 1の資本・投資ブロック正常動作
- [x] 型チェック・lint: パス

```bash
uv run pytest tests/ -v  # 95 passed
uv run mypy src/japan_fiscal_simulator  # Success
uv run ruff check src tests  # All checks passed
```