### PR TITLE
[codex] 設定の不変性とCI検証を強化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator
+
+      - name: Test
+        run: uv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ build/
 .pyscn/
 
 # Generated output
-output/
+/output/

--- a/src/japan_fiscal_simulator/parameters/defaults.py
+++ b/src/japan_fiscal_simulator/parameters/defaults.py
@@ -1,6 +1,7 @@
 """DSGEモデルのデフォルトパラメータ定義"""
 
 from dataclasses import dataclass, field, replace
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -129,7 +130,7 @@ class ShockParameters:
         }
 
 
-@dataclass
+@dataclass(frozen=True)
 class DefaultParameters:
     """全パラメータを統合したデフォルト設定"""
 
@@ -154,20 +155,16 @@ class DefaultParameters:
         shocks: ShockParameters | None = None,
     ) -> "DefaultParameters":
         """パラメータの一部を更新した新しいインスタンスを返す"""
+        updates: dict[str, Any] = {
+            "household": household,
+            "firm": firm,
+            "government": government,
+            "central_bank": central_bank,
+            "financial": financial,
+            "investment": investment,
+            "labor": labor,
+            "shocks": shocks,
+        }
         return replace(
-            self,
-            household=household if household is not None else self.household,
-            firm=firm if firm is not None else self.firm,
-            government=government if government is not None else self.government,
-            central_bank=central_bank if central_bank is not None else self.central_bank,
-            financial=financial if financial is not None else self.financial,
-            investment=investment if investment is not None else self.investment,
-            labor=labor if labor is not None else self.labor,
-            shocks=shocks if shocks is not None else self.shocks,
+            self, **{name: value for name, value in updates.items() if value is not None}
         )
-
-
-# 定数定義
-QUARTERS_PER_YEAR = 4
-DEFAULT_SIMULATION_PERIODS = 40  # 10年間
-DEFAULT_IMPULSE_SIZE = 0.01  # 1%ショック

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -152,6 +152,12 @@ class TestFrozenDataclassImmutability:
         with pytest.raises(FrozenInstanceError):
             params.alpha = 0.5  # type: ignore[misc]
 
+    def test_default_params_frozen(self) -> None:
+        """DefaultParametersも変更不可"""
+        params = DefaultParameters()
+        with pytest.raises(FrozenInstanceError):
+            params.household = HouseholdParameters(beta=0.5)  # type: ignore[misc]
+
 
 class TestCacheInvalidation:
     """キャッシュ無効化のテスト"""


### PR DESCRIPTION
## 概要

パラメータ設定の不変性と CI の回帰検証を強化します。周辺調査で見つかった `.gitignore` の過剰除外も修正します。

## 変更内容

- `DefaultParameters` を `frozen=True` にして配下の設定 dataclass と不変性を統一
- `DefaultParameters.with_updates()` を辞書駆動に簡素化
- 未使用だった `QUARTERS_PER_YEAR`, `DEFAULT_SIMULATION_PERIODS`, `DEFAULT_IMPULSE_SIZE` を削除
- `DefaultParameters` の不変性テストを追加
- `.gitignore` の `output/` を `/output/` に変更し、`src/japan_fiscal_simulator/output/` 配下の新規ソースが除外される問題を修正
- GitHub Actions に `uv run pytest` を追加

## 背景

ルートの `DefaultParameters` だけが可変で、モデル側が持つキャッシュ前提と不整合でした。また、CI は lint・format・mypy のみ実行しており、回帰テスト本体を実行していませんでした。

`.gitignore` の `output/` は非アンカー指定だったため、生成物ディレクトリだけでなくソースパッケージの `src/japan_fiscal_simulator/output/` に追加される新規ファイルも Git と一部検索ツールから除外していました。

## 検証

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src/japan_fiscal_simulator`
- `uv run pytest -q tests/test_edge_cases.py tests/test_parameter_mapping.py tests/test_labor_market.py tests/test_price_setting_phase3.py` (`67 passed`)
- `uv run pytest -q --ignore=tests/test_estimation_integration.py --ignore=tests/test_mcmc.py` (`406 passed`)
- `uv run pytest -q` (`438 passed`, 既存警告3件)

## フォローアップ

- #30
- #31
- #32
- #33
