### PR TITLE
消費税チャネルを水準効果・会計恒等式・債務累積に拡張

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         run: uv sync
 
       - name: Lint
-        run: uv run ruff check src tests
+        run: uv run ruff check src tests analysis
 
       - name: Format check
-        run: uv run ruff format --check src tests
+        run: uv run ruff format --check src tests analysis
 
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator

--- a/analysis/food_tax_1pct_2yr.py
+++ b/analysis/food_tax_1pct_2yr.py
@@ -1,0 +1,178 @@
+"""食料品消費税1%・2年限定の時限減税シミュレーション
+
+シナリオ:
+    食料品 8% → 1%（非食料品は10%据え置き）を「2年間（8四半期）限定」で実施し、
+    3年目（t=8）に元の制度へ復帰する。
+
+比較基準:
+    現行制度（食料品8%・非食料品10%、実効9.5%）からの変化。
+    食料品1%案の実効税率 = 0.25*1% + 0.75*10% = 7.75%
+    → 実効税率の変化 = 7.75% - 9.5% = -1.75%pt
+
+モデル化:
+    tau_c の遷移式は純粋AR(1):  tau_c_t = rho * tau_c_{t-1} + e_tau_t  (rho=0.95)
+    これを使い、税率を「t=0..7 で -1.75%pt 一定 → t=8 で 0 に復帰」と
+    なるようなショック列 e_tau_t を構築し、線形システムを重ね合わせで伝播させる:
+        x_0 = Q e_0
+        x_t = P x_{t-1} + Q e_t
+
+    比較用に、既存エンジン相当の「単発インパルス→AR(1)減衰」も並走させる。
+
+    注意（重要な限界）:
+        この重ね合わせは「各期ごとに政策の継続/終了を新しいショックとして
+        受け取る」非予見（unanticipated）型の経路。事前公表された終了時点を
+        家計が織り込む完全予見（perfect-foresight / news shock）型の前倒し効果は
+        この線形IRFエンジンでは厳密には表現されない。終了時点の反動（snap-back）は
+        t=8 の復帰ショックとして明示的に表現される。
+"""
+
+import numpy as np
+
+from japan_fiscal_simulator.core.model import N_SHOCKS, N_VARIABLES, VARIABLE_INDICES, DSGEModel
+from japan_fiscal_simulator.parameters.calibration import JapanCalibration
+
+E_TAU = 3  # ショックベクトルにおける消費税ショックのインデックス
+
+# 制度パラメータ
+FOOD_SHARE = 0.25
+CURRENT_FOOD, CURRENT_NONFOOD = 0.08, 0.10
+NEW_FOOD, NEW_NONFOOD = 0.01, 0.10
+
+CURRENT_EFFECTIVE = FOOD_SHARE * CURRENT_FOOD + (1 - FOOD_SHARE) * CURRENT_NONFOOD  # 9.5%
+NEW_EFFECTIVE = FOOD_SHARE * NEW_FOOD + (1 - FOOD_SHARE) * NEW_NONFOOD              # 7.75%
+SHOCK = NEW_EFFECTIVE - CURRENT_EFFECTIVE                                          # -1.75%pt
+
+HOLD_QUARTERS = 8   # 2年間維持
+PERIODS = 40
+
+
+def build_innovation_sequence(target: float, rho: float, hold: int, periods: int) -> np.ndarray:
+    """tau_c を t=0..hold-1 で target に保ち、t=hold で 0 に戻すための e_tau 列。
+
+    tau_c_t = rho * tau_c_{t-1} + e_tau_t
+      t=0          : e = target
+      t=1..hold-1  : e = (1-rho)*target   （減衰分を補填して水準維持）
+      t=hold       : e = -rho*target      （rho*target から 0 へ復帰）
+      t>hold       : e = 0                （0*rho=0 なので 0 を維持）
+    """
+    eps = np.zeros((periods + 1, N_SHOCKS))
+    eps[0, E_TAU] = target
+    for t in range(1, hold):
+        eps[t, E_TAU] = (1 - rho) * target
+    if hold <= periods:
+        eps[hold, E_TAU] = -rho * target
+    return eps
+
+
+def propagate(P: np.ndarray, Q: np.ndarray, eps: np.ndarray, periods: int) -> np.ndarray:
+    """ショック列 eps を線形システムに通して状態経路を返す。"""
+    x = np.zeros((periods + 1, N_VARIABLES))
+    x[0] = Q[:, :N_SHOCKS] @ eps[0]
+    for t in range(1, periods + 1):
+        x[t] = P @ x[t - 1] + Q[:, :N_SHOCKS] @ eps[t]
+    return x
+
+
+def single_impulse(P: np.ndarray, Q: np.ndarray, size: float, periods: int) -> np.ndarray:
+    """既存エンジン相当: t=0 に単発ショック→AR(1)減衰。"""
+    eps = np.zeros((periods + 1, N_SHOCKS))
+    eps[0, E_TAU] = size
+    return propagate(P, Q, eps, periods)
+
+
+def main() -> None:
+    model = DSGEModel(JapanCalibration.create().parameters)
+    pf = model.policy_function
+    P, Q = pf.P, pf.Q
+    rho = model.params.shocks.rho_tau_c
+    idx = VARIABLE_INDICES
+
+    print("=" * 70)
+    print("食料品消費税 1%・2年限定 時限減税シミュレーション")
+    print("=" * 70)
+    print(f"現行実効税率 : {CURRENT_EFFECTIVE*100:.2f}%  (食料品8% / 非食料品10%)")
+    print(f"新制度実効税率: {NEW_EFFECTIVE*100:.2f}%  (食料品1% / 非食料品10%)")
+    print(f"実効税率変化 : {SHOCK*100:+.2f}%pt   維持期間: {HOLD_QUARTERS}四半期")
+    print(f"AR(1)持続性 rho_tau_c = {rho}  /  BK条件: {pf.bk_satisfied}")
+    print()
+
+    eps_timed = build_innovation_sequence(SHOCK, rho, HOLD_QUARTERS, PERIODS)
+    x_timed = propagate(P, Q, eps_timed, PERIODS)
+    x_ar1 = single_impulse(P, Q, SHOCK, PERIODS)
+
+    def col(x, name):
+        return x[:, idx[name]]
+
+    # 経路確認: tau_c がきちんと維持・復帰しているか
+    print("税率(tau_c)経路の確認 [%pt 乖離]:")
+    tc = col(x_timed, "tau_c")
+    print("  四半期 :", " ".join(f"{q:>6d}" for q in [0, 1, 4, 7, 8, 9, 12]))
+    print("  時限版 :", " ".join(f"{tc[q]*100:>6.2f}" for q in [0, 1, 4, 7, 8, 9, 12]))
+    tca = col(x_ar1, "tau_c")
+    print("  AR1版  :", " ".join(f"{tca[q]*100:>6.2f}" for q in [0, 1, 4, 7, 8, 9, 12]))
+    print()
+
+    # 主要変数の経路
+    def summarize(label, x):
+        y, c, b = col(x, "y"), col(x, "c"), col(x, "b")
+        peak_y = y[np.argmax(np.abs(y))]
+        peak_c = c[np.argmax(np.abs(c))]
+        cum8_y = np.sum(y[:8])
+        print(f"[{label}]")
+        print(f"  GDP    ピーク: {peak_y*100:+.3f}%   2年累積(8Q): {cum8_y*100:+.3f}%pt·Q")
+        print(f"  消費   ピーク: {peak_c*100:+.3f}%")
+        print("  GDP    t=0..9: " + " ".join(f"{y[q]*100:+.2f}" for q in range(10)))
+        print("  消費   t=0..9: " + " ".join(f"{c[q]*100:+.2f}" for q in range(10)))
+        print("  政府債務 t=0..9: " + " ".join(f"{b[q]*100:+.2f}" for q in range(10)))
+        # 反動: 終了直後(t=8,9)で符号が反転しているか
+        print(f"  反動チェック GDP t=7→8→9: {y[7]*100:+.3f} → {y[8]*100:+.3f} → {y[9]*100:+.3f}")
+        print()
+
+    summarize("時限措置 (8Q維持→復帰)", x_timed)
+    summarize("AR(1)減衰 (参考)", x_ar1)
+
+    # 財政コストの目安: 減税期間中の税率低下 × 消費（GDP比で粗く）
+    tau_path = col(x_timed, "tau_c")
+    revenue_loss = -np.sum(tau_path[:HOLD_QUARTERS]) * FOOD_SHARE  # 食料消費に対する税率低下
+    print(f"参考: 減税期間中の食料品税収減の目安 ≈ {revenue_loss*100:.2f}%pt·Q (実効GDP比, 粗計算)")
+
+    # 図の保存
+    try:
+        import matplotlib  # noqa: PLC0415
+
+        matplotlib.use("Agg")
+        from pathlib import Path  # noqa: PLC0415
+
+        import matplotlib.pyplot as plt  # noqa: PLC0415
+
+        outdir = Path(__file__).resolve().parent.parent / "output" / "food_tax_1pct"
+        outdir.mkdir(parents=True, exist_ok=True)
+
+        t = np.arange(PERIODS + 1)
+        fig, axes = plt.subplots(2, 2, figsize=(12, 8))
+        panels = [
+            ("tau_c", "Effective consumption tax (%pt dev.)", 100),
+            ("y", "GDP (% dev.)", 100),
+            ("c", "Consumption (% dev.)", 100),
+            ("b", "Govt debt (% dev.)", 100),
+        ]
+        for ax, (var, title, scale) in zip(axes.flat, panels, strict=True):
+            ax.plot(t, col(x_timed, var) * scale, label="Time-limited (8Q hold -> revert)", lw=2)
+            ax.plot(t, col(x_ar1, var) * scale, label="AR(1) decay (ref.)", ls="--", lw=1.5)
+            ax.axvline(HOLD_QUARTERS, color="gray", ls=":", alpha=0.7)
+            ax.axhline(0, color="k", lw=0.5)
+            ax.set_title(title)
+            ax.set_xlabel("Quarter")
+            ax.legend(fontsize=8)
+            ax.grid(alpha=0.3)
+        fig.suptitle("Food consumption tax cut to 1%, 2-year time-limited", fontsize=13)
+        fig.tight_layout()
+        path = outdir / "food_tax_1pct_2yr.png"
+        fig.savefig(path, dpi=120)
+        print(f"\n図を保存: {path}")
+    except Exception as e:  # noqa: BLE001
+        print(f"\n図の生成をスキップ: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/food_tax_1pct_2yr.py
+++ b/analysis/food_tax_1pct_2yr.py
@@ -39,10 +39,10 @@ CURRENT_FOOD, CURRENT_NONFOOD = 0.08, 0.10
 NEW_FOOD, NEW_NONFOOD = 0.01, 0.10
 
 CURRENT_EFFECTIVE = FOOD_SHARE * CURRENT_FOOD + (1 - FOOD_SHARE) * CURRENT_NONFOOD  # 9.5%
-NEW_EFFECTIVE = FOOD_SHARE * NEW_FOOD + (1 - FOOD_SHARE) * NEW_NONFOOD              # 7.75%
-SHOCK = NEW_EFFECTIVE - CURRENT_EFFECTIVE                                          # -1.75%pt
+NEW_EFFECTIVE = FOOD_SHARE * NEW_FOOD + (1 - FOOD_SHARE) * NEW_NONFOOD  # 7.75%
+SHOCK = NEW_EFFECTIVE - CURRENT_EFFECTIVE  # -1.75%pt
 
-HOLD_QUARTERS = 8   # 2年間維持
+HOLD_QUARTERS = 8  # 2年間維持
 PERIODS = 40
 
 
@@ -80,8 +80,25 @@ def single_impulse(P: np.ndarray, Q: np.ndarray, size: float, periods: int) -> n
     return propagate(P, Q, eps, periods)
 
 
+def build_model() -> DSGEModel:
+    """現行制度の実効税率を定常状態とするモデルを構築する。"""
+    calibration = JapanCalibration.create().set_consumption_tax(CURRENT_EFFECTIVE)
+    return DSGEModel(calibration.parameters)
+
+
+def estimate_revenue_loss(model: DSGEModel, tau_path: np.ndarray, hold: int) -> float:
+    """実効税率の低下による税収減をGDP比で概算する。"""
+    ss = model.steady_state
+    c_y = ss.consumption / ss.output
+    elasticity = (
+        model.derived_coefficients.compute_impulse_coefficients().consumption_tax_elasticity
+    )
+    behavioral_adjustment = 1.0 - model.params.government.tau_c * elasticity
+    return -np.sum(tau_path[:hold]) * c_y * behavioral_adjustment
+
+
 def main() -> None:
-    model = DSGEModel(JapanCalibration.create().parameters)
+    model = build_model()
     pf = model.policy_function
     P, Q = pf.P, pf.Q
     rho = model.params.shocks.rho_tau_c
@@ -90,9 +107,9 @@ def main() -> None:
     print("=" * 70)
     print("食料品消費税 1%・2年限定 時限減税シミュレーション")
     print("=" * 70)
-    print(f"現行実効税率 : {CURRENT_EFFECTIVE*100:.2f}%  (食料品8% / 非食料品10%)")
-    print(f"新制度実効税率: {NEW_EFFECTIVE*100:.2f}%  (食料品1% / 非食料品10%)")
-    print(f"実効税率変化 : {SHOCK*100:+.2f}%pt   維持期間: {HOLD_QUARTERS}四半期")
+    print(f"現行実効税率 : {CURRENT_EFFECTIVE * 100:.2f}%  (食料品8% / 非食料品10%)")
+    print(f"新制度実効税率: {NEW_EFFECTIVE * 100:.2f}%  (食料品1% / 非食料品10%)")
+    print(f"実効税率変化 : {SHOCK * 100:+.2f}%pt   維持期間: {HOLD_QUARTERS}四半期")
     print(f"AR(1)持続性 rho_tau_c = {rho}  /  BK条件: {pf.bk_satisfied}")
     print()
 
@@ -107,9 +124,9 @@ def main() -> None:
     print("税率(tau_c)経路の確認 [%pt 乖離]:")
     tc = col(x_timed, "tau_c")
     print("  四半期 :", " ".join(f"{q:>6d}" for q in [0, 1, 4, 7, 8, 9, 12]))
-    print("  時限版 :", " ".join(f"{tc[q]*100:>6.2f}" for q in [0, 1, 4, 7, 8, 9, 12]))
+    print("  時限版 :", " ".join(f"{tc[q] * 100:>6.2f}" for q in [0, 1, 4, 7, 8, 9, 12]))
     tca = col(x_ar1, "tau_c")
-    print("  AR1版  :", " ".join(f"{tca[q]*100:>6.2f}" for q in [0, 1, 4, 7, 8, 9, 12]))
+    print("  AR1版  :", " ".join(f"{tca[q] * 100:>6.2f}" for q in [0, 1, 4, 7, 8, 9, 12]))
     print()
 
     # 主要変数の経路
@@ -119,22 +136,26 @@ def main() -> None:
         peak_c = c[np.argmax(np.abs(c))]
         cum8_y = np.sum(y[:8])
         print(f"[{label}]")
-        print(f"  GDP    ピーク: {peak_y*100:+.3f}%   2年累積(8Q): {cum8_y*100:+.3f}%pt·Q")
-        print(f"  消費   ピーク: {peak_c*100:+.3f}%")
-        print("  GDP    t=0..9: " + " ".join(f"{y[q]*100:+.2f}" for q in range(10)))
-        print("  消費   t=0..9: " + " ".join(f"{c[q]*100:+.2f}" for q in range(10)))
-        print("  政府債務 t=0..9: " + " ".join(f"{b[q]*100:+.2f}" for q in range(10)))
+        print(f"  GDP    ピーク: {peak_y * 100:+.3f}%   2年累積(8Q): {cum8_y * 100:+.3f}%pt·Q")
+        print(f"  消費   ピーク: {peak_c * 100:+.3f}%")
+        print("  GDP    t=0..9: " + " ".join(f"{y[q] * 100:+.2f}" for q in range(10)))
+        print("  消費   t=0..9: " + " ".join(f"{c[q] * 100:+.2f}" for q in range(10)))
+        print("  政府債務 t=0..9: " + " ".join(f"{b[q] * 100:+.2f}" for q in range(10)))
         # 反動: 終了直後(t=8,9)で符号が反転しているか
-        print(f"  反動チェック GDP t=7→8→9: {y[7]*100:+.3f} → {y[8]*100:+.3f} → {y[9]*100:+.3f}")
+        print(
+            f"  反動チェック GDP t=7→8→9: {y[7] * 100:+.3f} → {y[8] * 100:+.3f} → {y[9] * 100:+.3f}"
+        )
         print()
 
     summarize("時限措置 (8Q維持→復帰)", x_timed)
     summarize("AR(1)減衰 (参考)", x_ar1)
 
-    # 財政コストの目安: 減税期間中の税率低下 × 消費（GDP比で粗く）
+    # 財政コストの目安: 実効税率低下 × 消費/GDP（消費の行動反応を補正）
     tau_path = col(x_timed, "tau_c")
-    revenue_loss = -np.sum(tau_path[:HOLD_QUARTERS]) * FOOD_SHARE  # 食料消費に対する税率低下
-    print(f"参考: 減税期間中の食料品税収減の目安 ≈ {revenue_loss*100:.2f}%pt·Q (実効GDP比, 粗計算)")
+    revenue_loss = estimate_revenue_loss(model, tau_path, HOLD_QUARTERS)
+    print(
+        f"参考: 減税期間中の食料品税収減の目安 ≈ {revenue_loss * 100:.2f}%pt·Q (GDP比, 行動反応補正後)"
+    )
 
     # 図の保存
     try:

--- a/src/japan_fiscal_simulator/core/model.py
+++ b/src/japan_fiscal_simulator/core/model.py
@@ -213,14 +213,56 @@ class DSGEModel:
         Q[idx["b"], 1] = gov.g_y_ratio
 
         # e_tau: 消費税ショック (index 3)
+        #
+        # 消費税は (1) 相対価格を通じ消費へ波及し、(2) その税率「水準」が続く限り
+        # 効果が持続する。そこで税率水準を消費へ結線（P の tau_c 列）し、ショック
+        # 「変化」の瞬間は Q で表す。これにより c_t = -elasticity * tau_c_t が
+        # 毎期成り立ち、時限減税の維持期間中も消費が高止まりする。
+        # GDP は支出会計恒等式から導出し、消費との整合を保証する。債務は減税期間中
+        # 毎期の税収減をフローとして累積させる。
+        rho_tau = shocks.rho_tau_c
+        ss = self.steady_state
+        c_y = ss.consumption / ss.output
+        i_y = ss.investment / ss.output
+        g_y_share = ss.government_spending / ss.output
+        b_y = ss.government_debt / ss.output
+
+        # 税率はそれ自体が外生AR(1)（既存どおり）
         Q[idx["tau_c"], 3] = 1.0
-        Q[idx["c"], 3] = -imp.consumption_tax_elasticity
-        Q[idx["y"], 3] = -imp.consumption_tax_elasticity * imp.output_tax_multiplier_factor
-        Q[idx["pi"], 3] = imp.inflation_tax_passthrough
-        Q[idx["R"], 3] = cb.phi_pi * imp.inflation_tax_passthrough + cb.phi_y * (
-            -imp.consumption_tax_elasticity * imp.output_tax_multiplier_factor
+
+        # (1) 消費: 相対価格効果 c = -1/(1+tau) * tau。水準効果のため P にも結線
+        kappa_c = -imp.consumption_tax_elasticity
+        Q[idx["c"], 3] = kappa_c
+        P[idx["c"], idx["tau_c"]] = kappa_c * rho_tau
+
+        # (2) GDP: 支出会計恒等式 ŷ = (C/Y)ĉ + (I/Y)î + (G/Y)ĝ から導出
+        #     （投資・政府支出は消費税へ直接反応しないので実質 (C/Y)ĉ に等しい）
+        Q[idx["y"], 3] = c_y * Q[idx["c"], 3] + i_y * Q[idx["i"], 3] + g_y_share * Q[idx["g"], 3]
+        P[idx["y"], idx["tau_c"]] = (
+            c_y * P[idx["c"], idx["tau_c"]]
+            + i_y * P[idx["i"], idx["tau_c"]]
+            + g_y_share * P[idx["g"], idx["tau_c"]]
         )
-        Q[idx["b"], 3] = -imp.debt_tax_effect
+
+        # (3) インフレ: 税率「変化」の一度きりの価格転嫁（水準効果は持たせない）
+        Q[idx["pi"], 3] = imp.inflation_tax_passthrough
+
+        # (4) 名目金利: テイラールールで現在の pi と y に整合させる
+        Q[idx["R"], 3] = cb.phi_pi * Q[idx["pi"], 3] + cb.phi_y * Q[idx["y"], 3]
+        P[idx["R"], idx["tau_c"]] = (
+            cb.phi_pi * P[idx["pi"], idx["tau_c"]] + cb.phi_y * P[idx["y"], idx["tau_c"]]
+        )
+
+        # 実質金利 = 名目金利 - インフレ（line 166 の後に税チャネルを足すので明示更新）
+        Q[idx["r"], 3] = Q[idx["R"], 3] - Q[idx["pi"], 3]
+        P[idx["r"], idx["tau_c"]] = P[idx["R"], idx["tau_c"]] - P[idx["pi"], idx["tau_c"]]
+
+        # (5) 政府債務: 減税による税収減を毎期フローとして累積
+        #     deficit/債務 ≈ (C/Y)/(B/Y) * (1 - tau_ss*elasticity) * (-dtau)
+        #     （括弧内は税収のラッファー的な行動反応の補正）
+        kappa_b = -(c_y / b_y) * (1.0 - gov.tau_c * imp.consumption_tax_elasticity)
+        Q[idx["b"], 3] = kappa_b
+        P[idx["b"], idx["tau_c"]] = kappa_b * rho_tau
 
         # e_risk: リスクプレミアムショック (index 4)
         Q[idx["r"], 4] = imp.risk_interest_rate_response

--- a/src/japan_fiscal_simulator/core/model.py
+++ b/src/japan_fiscal_simulator/core/model.py
@@ -246,6 +246,8 @@ class DSGEModel:
 
         # (3) インフレ: 税率「変化」の一度きりの価格転嫁（水準効果は持たせない）
         Q[idx["pi"], 3] = imp.inflation_tax_passthrough
+        # dtau_t = (rho - 1) * tau_{t-1} + e_tau_t
+        P[idx["pi"], idx["tau_c"]] = imp.inflation_tax_passthrough * (rho_tau - 1.0)
 
         # (4) 名目金利: テイラールールで現在の pi と y に整合させる
         Q[idx["R"], 3] = cb.phi_pi * Q[idx["pi"], 3] + cb.phi_y * Q[idx["y"], 3]

--- a/tests/test_food_tax_analysis.py
+++ b/tests/test_food_tax_analysis.py
@@ -1,0 +1,57 @@
+"""食料品消費税の時限減税分析スクリプトのテスト"""
+
+import numpy as np
+
+from analysis.food_tax_1pct_2yr import (
+    CURRENT_EFFECTIVE,
+    HOLD_QUARTERS,
+    PERIODS,
+    SHOCK,
+    build_innovation_sequence,
+    build_model,
+    estimate_revenue_loss,
+    propagate,
+)
+from japan_fiscal_simulator.core.model import VARIABLE_INDICES
+
+
+def test_model_uses_current_effective_tax_rate_as_baseline() -> None:
+    """表示する現行実効税率とモデルの定常状態が一致する"""
+    model = build_model()
+    assert model.params.government.tau_c == CURRENT_EFFECTIVE
+
+
+def test_timed_tax_cut_only_changes_inflation_when_tax_rate_changes() -> None:
+    """維持用ショックは追加のインフレ転嫁を発生させない"""
+    model = build_model()
+    pf = model.policy_function
+    eps = build_innovation_sequence(SHOCK, model.params.shocks.rho_tau_c, HOLD_QUARTERS, PERIODS)
+    x = propagate(pf.P, pf.Q, eps, PERIODS)
+    idx = VARIABLE_INDICES
+
+    tau = x[:, idx["tau_c"]]
+    pi = x[:, idx["pi"]]
+    np.testing.assert_allclose(tau[:HOLD_QUARTERS], SHOCK)
+    np.testing.assert_allclose(tau[HOLD_QUARTERS:], 0.0, atol=1e-15)
+    np.testing.assert_allclose(pi[1:HOLD_QUARTERS], 0.0, atol=1e-15)
+    np.testing.assert_allclose(pi[HOLD_QUARTERS], -pi[0])
+    np.testing.assert_allclose(pi[HOLD_QUARTERS + 1 :], 0.0, atol=1e-15)
+
+
+def test_revenue_loss_uses_aggregate_consumption_share() -> None:
+    """実効税率差に食料品シェアを重ねて掛けない"""
+    model = build_model()
+    tau_path = np.full(HOLD_QUARTERS, SHOCK)
+    loss = estimate_revenue_loss(model, tau_path, HOLD_QUARTERS)
+    ss = model.steady_state
+    elasticity = (
+        model.derived_coefficients.compute_impulse_coefficients().consumption_tax_elasticity
+    )
+    expected = (
+        -SHOCK
+        * HOLD_QUARTERS
+        * (ss.consumption / ss.output)
+        * (1.0 - model.params.government.tau_c * elasticity)
+    )
+
+    np.testing.assert_allclose(loss, expected)

--- a/tests/test_irf_economics.py
+++ b/tests/test_irf_economics.py
@@ -118,6 +118,19 @@ class TestConsumptionTaxCutShock:
         y = irf.get_response("y")
         assert y[0] > 0
 
+    def test_inflation_tracks_tax_rate_changes(
+        self, model: DSGEModel, simulator: ImpulseResponseSimulator
+    ) -> None:
+        """インフレは税率水準ではなく税率変化に反応する"""
+        irf = simulator.simulate("e_tau", shock_size=-0.01, periods=4)
+        tau = irf.get_response("tau_c")
+        pi = irf.get_response("pi")
+        passthrough = (
+            model.derived_coefficients.compute_impulse_coefficients().inflation_tax_passthrough
+        )
+        delta_tau = np.diff(np.concatenate(([0.0], tau)))
+        np.testing.assert_allclose(pi, passthrough * delta_tau)
+
 
 # === 長期収束テスト ===
 


### PR DESCRIPTION
## 背景

食料品消費税1%・2年限定の時限減税シミュレーションを行う過程で、既存の消費税ショック(`e_tau`)チャネルに数値的な不整合が判明したため修正する。

旧モデルの問題点:
- **GDPと消費が会計的に不整合**: 消費はGDPの48.3%なのに、消費が+1.59%跳ねてもGDPは+0.40%しか上がらない（消費寄与+0.77%すら下回る）。`y`の税係数が `g_y/(1-g_y)` という根拠のない値だった。
- **税率の「水準」が波及しない**: `tau_c` は `state_cols` に含まれず自己持続するだけで、消費・GDPへの波及はショック注入の瞬間（Q行列）のみ。減税が続いても消費は1四半期で元の水準へ戻り、恒久減税と時限減税を区別できなかった。

## 変更内容（`core/model.py` の e_tau ブロック）

| # | 変更 | 内容 |
|---|---|---|
| 1 | 消費の水準チャネル | `P[c, tau_c] = -elasticity·ρ` を結線。`c_t = -elasticity·tau_c_t` が毎期成立し、減税が続く限り消費が高止まり |
| 2 | GDP=会計恒等式 | `ŷ = (C/Y)ĉ + (I/Y)î + (G/Y)ĝ` で導出。定常状態シェアを使い消費と整合 |
| 3 | インフレ | 税率「変化」の一度きりの価格転嫁のみ（水準効果なし＝恒久増税でも持続的インフレは生まない、で正しい） |
| 4 | 名目/実質金利 | テイラールールで新しい `y`・`pi` に整合 |
| 5 | 債務のフロー累積 | 毎期の税収減を累積。`κ_b = -(C/Y)/(B/Y)·(1-τ·elasticity)`（税収のラッファー的な行動反応を補正） |

`P[tau_c,tau_c]=0.95` と `Q[tau_c,3]=1.0` は不変（golden master維持）。

## 効果（食料品1%・2年限定・現行制度比 -1.75%pt）

| 指標 | 旧 | 拡張後 |
|---|---|---|
| 消費（維持期間中） | 初期+1.59%→即0 | **+1.59% が2年間持続** |
| GDP（維持期間中） | +0.40%（過小・不整合） | **+0.77% が2年間持続**（=0.483×1.59、整合） |
| 政府債務（2年後） | +0.47% | **+3.06%**（累積赤字、終了後も恒久残存） |

## 検証用スクリプト

`analysis/food_tax_1pct_2yr.py` を追加。税率を「8四半期一定→3年目に復帰」と制御するショック列で時限減税を構築し、AR(1)減衰版と比較する（図は `output/food_tax_1pct/` に出力、`.gitignore` 対象）。

## 既知の限界

- 完全予見（news shock）型の前倒し需要は表現されない。家計は各期ごとに政策の継続/終了を新規ショックとして受け取る非予見型の経路。
- 消費は現在の税ウェッジの静的関数のため、減税終了後にベースライン以下へ落ち込む反動（payback dip）は出ない。

## テスト

- コアの高速テスト 76件（golden master / IRF経済性質 / simulation / model / edge cases）全て green。符号・形状検証のため値固定の回帰はなし。
- 全体スイート（MCMC含む推定系）は実行に時間がかかるため別途確認中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)