### PR TITLE
[codex] テスト実行をslow層とfast層に分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: uv run mypy src/japan_fiscal_simulator
 
       - name: Test
-        run: uv run pytest
+        run: uv run pytest -m "" -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,17 @@ follow_untyped_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
+markers = [
+    "slow: 重い統合テスト（MCMC/推定系）",
+]
+addopts = "-m 'not slow' --durations=10"
 
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.14.14",
     "scipy-stubs>=1.17.0",
 ]

--- a/tests/test_estimation_integration.py
+++ b/tests/test_estimation_integration.py
@@ -23,6 +23,8 @@ from japan_fiscal_simulator.estimation.results import (
 from japan_fiscal_simulator.estimation.state_space import StateSpaceBuilder
 from japan_fiscal_simulator.parameters.defaults import DefaultParameters
 
+pytestmark = pytest.mark.slow
+
 
 class TestEstimationPipeline:
     """推定パイプライン全体の統合テスト"""

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -47,6 +47,7 @@ class TestMCMCConfig:
         assert cfg.n_draws == 500
 
 
+@pytest.mark.slow
 class TestMetropolisHastingsGaussian:
     """ガウスターゲットでのMHサンプラーテスト"""
 
@@ -227,6 +228,7 @@ class TestMakeLogPosterior:
         assert isinstance(lp, float)
 
 
+@pytest.mark.slow
 class TestMCMCWithDSGE:
     """DSGEモデルを使ったMCMC統合テスト（軽量）"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -294,6 +294,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.61.1"
 source = { registry = "https://pypi.org/simple" }
@@ -431,6 +440,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scipy-stubs" },
 ]
@@ -458,6 +468,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "scipy-stubs", specifier = ">=1.17.0" },
 ]
@@ -1127,6 +1138,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

- pytest の `slow` マーカーを登録し、デフォルト実行では slow テストを除外するようにしました
- MCMC/推定統合系の重いテストを `slow` に分類しました
- `pytest-xdist` を dev 依存に追加し、CI では slow 含み全件を `-n auto` で実行するようにしました

## 背景

issue #36 の対応です。通常の `uv run pytest` を開発時の fast path にしつつ、CI では `-m ""` で marker 除外を解除して全件を実行します。

## 確認

- `uv run pytest -q` -> `417 passed, 26 deselected, 1 warning in 4.36s`
- `uv run ruff check src tests analysis`
- `uv run ruff format --check src tests analysis`
- `uv run pytest --collect-only -q -m slow` -> slow 26 件を収集
- `uv run pytest --collect-only -q -m "" -n auto` -> 全 443 件を収集

## 補足

`uv run pytest -m slow` の完走確認はローカルで 6 分超となったため中断しました。二層化により通常の内ループは高速化済みで、slow 側の実時間短縮は fixture 共有や MCMC 実行削減を別途見る余地があります。