### PR TITLE
パラメータ生成時にfail-fastバリデーションを追加

### DIFF
--- a/src/japan_fiscal_simulator/parameters/defaults.py
+++ b/src/japan_fiscal_simulator/parameters/defaults.py
@@ -1,7 +1,48 @@
 """DSGEモデルのデフォルトパラメータ定義"""
 
+import math
 from dataclasses import dataclass, field, replace
 from typing import Any
+
+from japan_fiscal_simulator.core.exceptions import ParameterValidationError
+
+
+def _validate(
+    owner: str,
+    name: str,
+    value: float,
+    low: float | None = None,
+    high: float | None = None,
+    *,
+    low_open: bool = False,
+    high_open: bool = False,
+) -> None:
+    """パラメータが有限かつ許容範囲内であることを検証する
+
+    検証境界はMCMCの探索範囲（ParameterMapping.ESTIMATED_PARAMS）を
+    すべて内包するように設計されている。経済学的に珍しいだけの値
+    （例: テイラー原理違反のphi_pi < 1）は拒否しない。
+
+    Raises:
+        ParameterValidationError: 値が非有限または範囲外の場合
+    """
+    try:
+        is_finite = math.isfinite(value)
+    except TypeError:
+        is_finite = False
+    if not is_finite:
+        raise ParameterValidationError(f"{owner}.{name}={value!r} は有限の数値である必要があります")
+    in_range = True
+    if low is not None:
+        in_range = value > low if low_open else value >= low
+    if in_range and high is not None:
+        in_range = value < high if high_open else value <= high
+    if not in_range:
+        lower = f"{low} {'<' if low_open else '<='} " if low is not None else ""
+        upper = f" {'<' if high_open else '<='} {high}" if high is not None else ""
+        raise ParameterValidationError(
+            f"{owner}.{name}={value} が有効範囲外です（{lower}{name}{upper}）"
+        )
 
 
 @dataclass(frozen=True)
@@ -14,6 +55,14 @@ class HouseholdParameters:
     habit: float = 0.7  # 習慣形成パラメータ
     chi: float = 1.0  # 労働の不効用パラメータ
 
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "beta", self.beta, 0.0, 1.0, low_open=True, high_open=True)
+        _validate(owner, "sigma", self.sigma, 0.0, low_open=True)
+        _validate(owner, "phi", self.phi, 0.0, low_open=True)
+        _validate(owner, "habit", self.habit, 0.0, 1.0, high_open=True)
+        _validate(owner, "chi", self.chi, 0.0, low_open=True)
+
 
 @dataclass(frozen=True)
 class FirmParameters:
@@ -24,6 +73,16 @@ class FirmParameters:
     theta: float = 0.75  # Calvo価格硬直性（75%が価格維持）
     epsilon: float = 6.0  # 財の代替弾力性
     psi: float = 0.5  # 価格インデクセーション
+
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "alpha", self.alpha, 0.0, 1.0, low_open=True, high_open=True)
+        _validate(owner, "delta", self.delta, 0.0, 1.0, low_open=True)
+        # theta=0はPhillips曲線スロープ (1-θ)(1-βθ)/θ でゼロ除算になる
+        _validate(owner, "theta", self.theta, 0.0, 1.0, low_open=True, high_open=True)
+        # マークアップ ε/(ε-1) が定義できるのは ε > 1 のみ
+        _validate(owner, "epsilon", self.epsilon, 1.0, low_open=True)
+        _validate(owner, "psi", self.psi, 0.0, 1.0)
 
     @property
     def iota_p(self) -> float:
@@ -45,6 +104,18 @@ class GovernmentParameters:
     rho_tau: float = 0.90  # 税率の持続性
     phi_b: float = 0.02  # 債務安定化係数
 
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "tau_c", self.tau_c, 0.0, 1.0, high_open=True)
+        _validate(owner, "tau_l", self.tau_l, 0.0, 1.0, high_open=True)
+        _validate(owner, "tau_k", self.tau_k, 0.0, 1.0, high_open=True)
+        _validate(owner, "g_y_ratio", self.g_y_ratio, 0.0, 1.0, high_open=True)
+        _validate(owner, "b_y_ratio", self.b_y_ratio, 0.0)
+        _validate(owner, "transfer_y_ratio", self.transfer_y_ratio, 0.0, 1.0, high_open=True)
+        _validate(owner, "rho_g", self.rho_g, 0.0, 1.0, high_open=True)
+        _validate(owner, "rho_tau", self.rho_tau, 0.0, 1.0, high_open=True)
+        _validate(owner, "phi_b", self.phi_b, 0.0)
+
 
 @dataclass(frozen=True)
 class CentralBankParameters:
@@ -56,6 +127,15 @@ class CentralBankParameters:
     pi_target: float = 0.005  # インフレ目標（四半期、年率2%）
     r_lower_bound: float = -0.001  # 名目金利下限（ZLB、若干のマイナス金利許容）
 
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "rho_r", self.rho_r, 0.0, 1.0, high_open=True)
+        # phi_pi < 1（テイラー原理違反）は不決定性の検証に使うため有限性のみ確認する
+        _validate(owner, "phi_pi", self.phi_pi)
+        _validate(owner, "phi_y", self.phi_y)
+        _validate(owner, "pi_target", self.pi_target)
+        _validate(owner, "r_lower_bound", self.r_lower_bound)
+
 
 @dataclass(frozen=True)
 class FinancialParameters:
@@ -64,6 +144,13 @@ class FinancialParameters:
     chi_b: float = 0.05  # 外部資金プレミアム弾力性
     leverage_ss: float = 2.0  # 定常状態レバレッジ
     survival_rate: float = 0.975  # 企業家生存率
+
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "chi_b", self.chi_b, 0.0)
+        # 定常状態で nw = k / leverage_ss を計算するためゼロは不可
+        _validate(owner, "leverage_ss", self.leverage_ss, 0.0, low_open=True)
+        _validate(owner, "survival_rate", self.survival_rate, 0.0, 1.0, low_open=True)
 
 
 @dataclass(frozen=True)
@@ -76,6 +163,12 @@ class OpenEconomyParameters:
     # 1.0 で「物価上昇分＝実質所得の目減り」を意味する（インフレ転嫁チャネルと整合）。
     # 交易条件・輸入数量効果を上乗せしたい場合のみ 1.0 超に設定する。
     eta: float = 1.0
+
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "import_share", self.import_share, 0.0, 1.0, high_open=True)
+        _validate(owner, "exchange_rate_passthrough", self.exchange_rate_passthrough, 0.0, 1.0)
+        _validate(owner, "eta", self.eta, 0.0)
 
     @property
     def psi_m(self) -> float:
@@ -100,6 +193,10 @@ class InvestmentParameters:
     # 投資調整コスト曲率: Smets-Wouters (2007) の推定値 5.48 を参考に設定
     S_double_prime: float = 5.0
 
+    def __post_init__(self) -> None:
+        # 投資方程式の係数 1/S'' を計算するためゼロは不可
+        _validate(type(self).__name__, "S_double_prime", self.S_double_prime, 0.0, low_open=True)
+
 
 @dataclass(frozen=True)
 class LaborParameters:
@@ -114,6 +211,13 @@ class LaborParameters:
     theta_w: float = 0.75  # Calvo賃金硬直性（75%が賃金維持）
     epsilon_w: float = 10.0  # 労働の代替弾力性
     iota_w: float = 0.5  # 賃金インデクセーション（0=後向き、1=前向き）
+
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        _validate(owner, "theta_w", self.theta_w, 0.0, 1.0, low_open=True, high_open=True)
+        # 賃金マークアップ ε_w/(ε_w-1) が定義できるのは ε_w > 1 のみ
+        _validate(owner, "epsilon_w", self.epsilon_w, 1.0, low_open=True)
+        _validate(owner, "iota_w", self.iota_w, 0.0, 1.0)
 
 
 @dataclass(frozen=True)
@@ -144,6 +248,34 @@ class ShockParameters:
     sigma_i: float = 0.01
     sigma_w: float = 0.01  # 賃金マークアップショック
     sigma_p: float = 0.01  # 価格マークアップショック
+
+    def __post_init__(self) -> None:
+        owner = type(self).__name__
+        # AR(1)持続性は定常性のため [0, 1) に制限
+        for name in (
+            "rho_a",
+            "rho_g",
+            "rho_tau_c",
+            "rho_m",
+            "rho_risk",
+            "rho_fx",
+            "rho_i",
+            "rho_w",
+            "rho_p",
+        ):
+            _validate(owner, name, getattr(self, name), 0.0, 1.0, high_open=True)
+        for name in (
+            "sigma_a",
+            "sigma_g",
+            "sigma_tau_c",
+            "sigma_m",
+            "sigma_risk",
+            "sigma_fx",
+            "sigma_i",
+            "sigma_w",
+            "sigma_p",
+        ):
+            _validate(owner, name, getattr(self, name), 0.0)
 
     @property
     def persistent_non_state_shocks(self) -> dict[str, float]:

--- a/tests/test_capital_investment.py
+++ b/tests/test_capital_investment.py
@@ -1,5 +1,7 @@
 """資本蓄積と投資方程式のテスト"""
 
+from dataclasses import replace
+
 import numpy as np
 import pytest
 
@@ -257,23 +259,10 @@ class TestNewKeynesianModelExpanded:
         assert irf["rk"][0] > 0
 
     def test_invalid_resource_share_raises(self) -> None:
-        """資源制約シェアが不正な場合は例外を投げる"""
+        """資源制約シェアが不正な場合は生成時に例外を投げる（fail-fast）"""
         params = DefaultParameters()
-        bad_government = params.government.__class__(
-            tau_c=params.government.tau_c,
-            tau_l=params.government.tau_l,
-            tau_k=params.government.tau_k,
-            g_y_ratio=-0.1,
-            b_y_ratio=params.government.b_y_ratio,
-            transfer_y_ratio=params.government.transfer_y_ratio,
-            rho_g=params.government.rho_g,
-            rho_tau=params.government.rho_tau,
-            phi_b=params.government.phi_b,
-        )
-        bad_params = params.with_updates(government=bad_government)
-        model = NewKeynesianModel(bad_params)
         with pytest.raises(ValidationError):
-            _ = model.solution
+            replace(params.government, g_y_ratio=-0.1)
 
 
 class TestDSGEModelExpanded:

--- a/tests/test_parameter_validation.py
+++ b/tests/test_parameter_validation.py
@@ -1,0 +1,164 @@
+"""パラメータ生成時のfail-fastバリデーションのテスト（issue #30）"""
+
+import math
+from dataclasses import replace
+
+import pytest
+
+from japan_fiscal_simulator.core.exceptions import ParameterValidationError
+from japan_fiscal_simulator.estimation.parameter_mapping import ParameterMapping
+from japan_fiscal_simulator.parameters.calibration import JapanCalibration
+from japan_fiscal_simulator.parameters.defaults import (
+    CentralBankParameters,
+    DefaultParameters,
+    FinancialParameters,
+    FirmParameters,
+    GovernmentParameters,
+    HouseholdParameters,
+    InvestmentParameters,
+    LaborParameters,
+    OpenEconomyParameters,
+    ShockParameters,
+)
+
+
+class TestInvalidValuesRejected:
+    """issue #30 で確認された不正値が生成時に拒否される"""
+
+    def test_negative_consumption_tax_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            GovernmentParameters(tau_c=-0.1)
+
+    def test_beta_zero_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            HouseholdParameters(beta=0.0)
+
+    def test_beta_one_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            HouseholdParameters(beta=1.0)
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_rejected(self, value: float) -> None:
+        with pytest.raises(ParameterValidationError):
+            HouseholdParameters(beta=value)
+
+    def test_replace_path_also_validated(self) -> None:
+        """dataclasses.replace経由でも__post_init__が再実行され検証される"""
+        with pytest.raises(ParameterValidationError):
+            replace(HouseholdParameters(), habit=1.5)
+
+    def test_theta_zero_rejected(self) -> None:
+        """theta=0はPhillips曲線スロープのゼロ除算になるため拒否"""
+        with pytest.raises(ParameterValidationError):
+            FirmParameters(theta=0.0)
+
+    def test_epsilon_at_most_one_rejected(self) -> None:
+        """ε<=1ではマークアップ ε/(ε-1) が定義できない"""
+        with pytest.raises(ParameterValidationError):
+            FirmParameters(epsilon=1.0)
+
+    def test_unit_root_shock_persistence_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            ShockParameters(rho_a=1.0)
+
+    def test_negative_shock_std_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            ShockParameters(sigma_g=-0.01)
+
+    def test_zero_investment_adjustment_cost_rejected(self) -> None:
+        """投資方程式の係数 1/S'' が計算できないため拒否"""
+        with pytest.raises(ParameterValidationError):
+            InvestmentParameters(S_double_prime=0.0)
+
+    def test_zero_leverage_rejected(self) -> None:
+        """定常状態の nw = k / leverage_ss が計算できないため拒否"""
+        with pytest.raises(ParameterValidationError):
+            FinancialParameters(leverage_ss=0.0)
+
+    def test_labor_elasticity_at_most_one_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            LaborParameters(epsilon_w=1.0)
+
+    def test_import_share_one_rejected(self) -> None:
+        with pytest.raises(ParameterValidationError):
+            OpenEconomyParameters(import_share=1.0)
+
+
+class TestErrorMessages:
+    """エラーメッセージから対象パラメータと値を特定できる"""
+
+    def test_message_contains_class_field_and_value(self) -> None:
+        with pytest.raises(ParameterValidationError, match=r"GovernmentParameters\.tau_c=-0\.1"):
+            GovernmentParameters(tau_c=-0.1)
+
+    def test_message_contains_range(self) -> None:
+        with pytest.raises(ParameterValidationError, match=r"0\.0 < beta < 1\.0"):
+            HouseholdParameters(beta=0.0)
+
+    def test_non_finite_message_identifies_parameter(self) -> None:
+        with pytest.raises(ParameterValidationError, match=r"HouseholdParameters\.beta=nan"):
+            HouseholdParameters(beta=float("nan"))
+
+
+class TestBoundaryValuesAccepted:
+    """境界上の正常値は受理される"""
+
+    def test_zero_habit_accepted(self) -> None:
+        assert HouseholdParameters(habit=0.0).habit == 0.0
+
+    def test_zero_taxes_accepted(self) -> None:
+        params = GovernmentParameters(tau_c=0.0, tau_l=0.0, tau_k=0.0)
+        assert params.tau_c == 0.0
+
+    def test_full_depreciation_accepted(self) -> None:
+        assert FirmParameters(delta=1.0).delta == 1.0
+
+    def test_psi_bounds_accepted(self) -> None:
+        assert FirmParameters(psi=0.0).psi == 0.0
+        assert FirmParameters(psi=1.0).psi == 1.0
+
+    def test_zero_shock_std_accepted(self) -> None:
+        assert ShockParameters(sigma_a=0.0).sigma_a == 0.0
+
+    def test_taylor_principle_violation_allowed(self) -> None:
+        """phi_pi < 1は不決定性の検証に使うため拒否しない（test_solver.py参照）"""
+        assert CentralBankParameters(phi_pi=0.8).phi_pi == 0.8
+
+    def test_negative_policy_coefficients_allowed(self) -> None:
+        assert CentralBankParameters(phi_y=-0.1, r_lower_bound=-0.01).phi_y == -0.1
+
+
+class TestExistingCalibrationsStillValid:
+    """既存のキャリブレーションがすべて検証を通過する"""
+
+    def test_default_parameters(self) -> None:
+        assert DefaultParameters() is not None
+
+    def test_japan_baseline(self) -> None:
+        assert JapanCalibration.create() is not None
+
+    def test_japan_high_debt(self) -> None:
+        assert JapanCalibration.create_high_debt_scenario() is not None
+
+    def test_japan_zlb(self) -> None:
+        assert JapanCalibration.create_zlb_scenario() is not None
+
+
+class TestMCMCBoundsCompatibility:
+    """検証境界がMCMCの探索範囲を内包する"""
+
+    def test_theta_at_mcmc_lower_bounds_accepted(self) -> None:
+        mapping = ParameterMapping()
+        theta = mapping.defaults()
+        for i, (low, _) in enumerate(mapping.bounds()):
+            if math.isfinite(low):
+                theta[i] = low
+        assert mapping.theta_to_params(theta) is not None
+
+    def test_theta_at_mcmc_upper_bounds_accepted(self) -> None:
+        mapping = ParameterMapping()
+        theta = mapping.defaults()
+        for i, (_, high) in enumerate(mapping.bounds()):
+            if math.isfinite(high):
+                theta[i] = high
+        assert mapping.theta_to_params(theta) is not None


### PR DESCRIPTION
## 概要

Closes #30

`DefaultParameters` 配下の各パラメータ dataclass に `__post_init__` バリデーションを追加し、不正値を生成時点で `ParameterValidationError` として拒否するようにしました。

## 変更内容

- `parameters/defaults.py`: 全9つのパラメータ dataclass に `__post_init__` を追加
  - 非有限値（NaN / ±inf）はすべて拒否
  - 構造的に不正な値のみ拒否する設計:
    - `beta ∈ (0, 1)`（`beta=0` の `ZeroDivisionError` を防止）
    - 税率 `tau_c`, `tau_l`, `tau_k ∈ [0, 1)`（`tau_c=-0.1` を拒否）
    - `theta`, `theta_w ∈ (0, 1)`（Phillips曲線スロープのゼロ除算を防止）
    - `epsilon`, `epsilon_w > 1`（マークアップ `ε/(ε-1)` の定義域）
    - `S_double_prime > 0`（投資方程式の係数 `1/S''`）
    - `leverage_ss > 0`（定常状態の `nw = k / leverage_ss`）
    - ショック持続性 `rho_* ∈ [0, 1)`（定常性）
- `tests/test_parameter_validation.py`: 境界値・不正値・エラーメッセージのテストを31件追加
- `tests/test_capital_investment.py`: `g_y_ratio=-0.1` が生成時に拒否されるようになったため、fail-fast 挙動に合わせて更新

## 設計上の判断

- **MCMC探索範囲との整合**: 検証境界は `ParameterMapping.ESTIMATED_PARAMS` の探索範囲をすべて内包するように設計（テストで担保）。また `mcmc.py` の `log_posterior` は prior 評価が `theta_to_params` より先のため、範囲外の提案は従来どおり prior で棄却される
- **`phi_pi` は有限性のみチェック**: テイラー原理違反（`phi_pi < 1`）は不決定性の検証（`test_solver.py`）に使われており、prior も unbounded NORMAL のため拒否しない
- **`dataclasses.replace` 経由でも検証される**: frozen dataclass の `replace` は `__init__` を再実行するため、`parameter_mapping.py` や `calibration.py` の更新経路もカバー

## テスト

- `uv run pytest -m "not slow"`: 454 passed
- `uv run mypy src/japan_fiscal_simulator`: エラーなし
- `uv run ruff check` / `ruff format --check`: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)