### PR TITLE
政策関数ソルバーに解析的ヤコビアンを追加してCIを高速化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,21 +36,20 @@ jobs:
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator
 
-      - name: Diagnose - raw model solve timing
+      - name: Diagnose - profile model solve
         run: |
           uv run python -c "
-          import time
+          import cProfile, pstats, io, time
           from japan_fiscal_simulator.core.model import DSGEModel
           from japan_fiscal_simulator.parameters.defaults import DefaultParameters
-          t = time.time(); m = DSGEModel(DefaultParameters()); _ = m.policy_function
-          print(f'model solve: {time.time() - t:.2f}s')
+          pr = cProfile.Profile(); pr.enable()
+          m = DSGEModel(DefaultParameters()); _ = m.policy_function
+          pr.disable()
+          s = io.StringIO(); pstats.Stats(pr, stream=s).sort_stats('cumulative').print_stats(25)
+          print(s.getvalue())
+          t = time.time(); m2 = DSGEModel(DefaultParameters()); _ = m2.policy_function
+          print(f'second solve (warm): {time.time() - t:.2f}s')
           "
-
-      - name: Diagnose - slow tests solo without xdist
-        run: uv run pytest tests/test_docs.py::TestEstimation::test_make_log_posterior tests/test_data_loader.py -q --durations=5 -p no:cacheprovider
-
-      - name: Diagnose - same tests with xdist
-        run: uv run pytest tests/test_docs.py::TestEstimation::test_make_log_posterior tests/test_data_loader.py -q --durations=5 -n auto
 
       - name: Test
         run: uv run pytest -m "not slow" -n auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      # pytest-xdistのワーカーごとにBLASが全コア分のスレッドを張ると
-      # 競合してテストが極端に遅くなるため、1ワーカー1スレッドに制限する
+      # pytest-xdistのワーカーごとにBLASが全コア分のスレッドを張る
+      # 過剰購読を予防する（1ワーカー1スレッド）
       OMP_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
       MKL_NUM_THREADS: 1
@@ -35,16 +35,6 @@ jobs:
 
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator
-
-      - name: Diagnose - model solve timing with analytic jacobian
-        run: |
-          uv run python -c "
-          import time
-          from japan_fiscal_simulator.core.model import DSGEModel
-          from japan_fiscal_simulator.parameters.defaults import DefaultParameters
-          t = time.time(); m = DSGEModel(DefaultParameters()); _ = m.policy_function
-          print(f'model solve: {time.time() - t:.3f}s')
-          "
 
       - name: Test
         run: uv run pytest -m "not slow" -n auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,36 +36,14 @@ jobs:
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator
 
-      - name: Diagnose - hybr solver behavior
+      - name: Diagnose - model solve timing with analytic jacobian
         run: |
           uv run python -c "
-          import numpy as np
-          from scipy.optimize import root
-          from japan_fiscal_simulator.core.nk_model import NewKeynesianModel
-          from japan_fiscal_simulator.core.solver import BlanchardKahnSolver
+          import time
+          from japan_fiscal_simulator.core.model import DSGEModel
           from japan_fiscal_simulator.parameters.defaults import DefaultParameters
-
-          model = NewKeynesianModel(DefaultParameters())
-          mats = model._build_system_matrices()
-          s = BlanchardKahnSolver(
-              A=mats.A, B=mats.B, C=mats.C, D=mats.D,
-              n_predetermined=model.vars.n_state,
-              n_forward_looking=int(np.linalg.matrix_rank(mats.A)),
-          )
-          ns, nc = s.n_state, s.n_control
-          I = np.eye(ns)
-          def residual(vec):
-              P = vec[:ns*ns].reshape(ns, ns); R = vec[ns*ns:].reshape(nc, ns)
-              F = np.vstack([I, R])
-              return np.asarray(s.A @ F @ (P @ P) + s.B @ F @ P + s.C @ F, dtype=float).reshape(-1)
-          x0 = s._initial_guess()
-          sol = root(residual, x0=x0, method='hybr', tol=1e-10)
-          err = float(np.linalg.norm(residual(sol.x), ord=np.inf))
-          print('success:', sol.success)
-          print('message:', sol.message)
-          print('err:', err)
-          print('nfev:', sol.nfev)
-          print('x0[:5]:', x0[:5])
+          t = time.time(); m = DSGEModel(DefaultParameters()); _ = m.policy_function
+          print(f'model solve: {time.time() - t:.3f}s')
           "
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,19 +36,36 @@ jobs:
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator
 
-      - name: Diagnose - profile model solve
+      - name: Diagnose - hybr solver behavior
         run: |
           uv run python -c "
-          import cProfile, pstats, io, time
-          from japan_fiscal_simulator.core.model import DSGEModel
+          import numpy as np
+          from scipy.optimize import root
+          from japan_fiscal_simulator.core.nk_model import NewKeynesianModel
+          from japan_fiscal_simulator.core.solver import BlanchardKahnSolver
           from japan_fiscal_simulator.parameters.defaults import DefaultParameters
-          pr = cProfile.Profile(); pr.enable()
-          m = DSGEModel(DefaultParameters()); _ = m.policy_function
-          pr.disable()
-          s = io.StringIO(); pstats.Stats(pr, stream=s).sort_stats('cumulative').print_stats(25)
-          print(s.getvalue())
-          t = time.time(); m2 = DSGEModel(DefaultParameters()); _ = m2.policy_function
-          print(f'second solve (warm): {time.time() - t:.2f}s')
+
+          model = NewKeynesianModel(DefaultParameters())
+          mats = model._build_system_matrices()
+          s = BlanchardKahnSolver(
+              A=mats.A, B=mats.B, C=mats.C, D=mats.D,
+              n_predetermined=model.vars.n_state,
+              n_forward_looking=int(np.linalg.matrix_rank(mats.A)),
+          )
+          ns, nc = s.n_state, s.n_control
+          I = np.eye(ns)
+          def residual(vec):
+              P = vec[:ns*ns].reshape(ns, ns); R = vec[ns*ns:].reshape(nc, ns)
+              F = np.vstack([I, R])
+              return np.asarray(s.A @ F @ (P @ P) + s.B @ F @ P + s.C @ F, dtype=float).reshape(-1)
+          x0 = s._initial_guess()
+          sol = root(residual, x0=x0, method='hybr', tol=1e-10)
+          err = float(np.linalg.norm(residual(sol.x), ord=np.inf))
+          print('success:', sol.success)
+          print('message:', sol.message)
+          print('err:', err)
+          print('nfev:', sol.nfev)
+          print('x0[:5]:', x0[:5])
           "
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # pytest-xdistのワーカーごとにBLASが全コア分のスレッドを張ると
+      # 競合してテストが極端に遅くなるため、1ワーカー1スレッドに制限する
+      OMP_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,21 @@ jobs:
       - name: Type check
         run: uv run mypy src/japan_fiscal_simulator
 
+      - name: Diagnose - raw model solve timing
+        run: |
+          uv run python -c "
+          import time
+          from japan_fiscal_simulator.core.model import DSGEModel
+          from japan_fiscal_simulator.parameters.defaults import DefaultParameters
+          t = time.time(); m = DSGEModel(DefaultParameters()); _ = m.policy_function
+          print(f'model solve: {time.time() - t:.2f}s')
+          "
+
+      - name: Diagnose - slow tests solo without xdist
+        run: uv run pytest tests/test_docs.py::TestEstimation::test_make_log_posterior tests/test_data_loader.py -q --durations=5 -p no:cacheprovider
+
+      - name: Diagnose - same tests with xdist
+        run: uv run pytest tests/test_docs.py::TestEstimation::test_make_log_posterior tests/test_data_loader.py -q --durations=5 -n auto
+
       - name: Test
         run: uv run pytest -m "not slow" -n auto

--- a/src/japan_fiscal_simulator/core/solver.py
+++ b/src/japan_fiscal_simulator/core/solver.py
@@ -203,8 +203,29 @@ class BlanchardKahnSolver:
             det_residual = self.A @ F @ (P @ P) + self.B @ F @ P + self.C @ F
             return np.asarray(det_residual, dtype=float).reshape(-1)
 
+        # dF/dR の選択行列: F = [I; R] なので dF = S @ dR
+        selector = np.vstack([np.zeros((ns, nc)), np.eye(nc)])
+
+        def jacobian(vec: np.ndarray) -> np.ndarray:
+            # 残差 M = A F P^2 + B F P + C F の解析的ヤコビアン。
+            # 行優先ベクトル化では vec_r(A X B) = (A ⊗ B^T) vec_r(X) を用いて
+            #   dM/dP = (AF) ⊗ P^T + (AFP + BF) ⊗ I
+            #   dM/dR = (AS) ⊗ (P^2)^T + (BS) ⊗ P^T + (CS) ⊗ I
+            # 数値微分のノイズで準ニュートン法が停滞するのを防ぐ。
+            P, R = unpack(vec)
+            F = np.vstack([identity_state, R])
+            AF = self.A @ F
+            BF = self.B @ F
+            J_P = np.kron(AF, P.T) + np.kron(AF @ P + BF, identity_state)
+            J_R = (
+                np.kron(self.A @ selector, (P @ P).T)
+                + np.kron(self.B @ selector, P.T)
+                + np.kron(self.C @ selector, identity_state)
+            )
+            return np.hstack([J_P, J_R])
+
         x0 = self._initial_guess()
-        solution = root(residual, x0=x0, method="hybr", tol=tol)
+        solution = root(residual, x0=x0, jac=jacobian, method="hybr", tol=tol)
         x_candidate = np.asarray(solution.x, dtype=float)
         err = float(np.linalg.norm(residual(x_candidate), ord=np.inf))
         used_fallback = False
@@ -221,6 +242,7 @@ class BlanchardKahnSolver:
                 lsq = least_squares(
                     residual,
                     x0=guess,
+                    jac=jacobian,
                     method="dogbox",
                     ftol=tol,
                     xtol=tol,


### PR DESCRIPTION
## 概要

CIのテストが約15分かかっていた問題の修正です。slowテスト除外後もローカルでは数秒で終わるテストスイートがCIで14分以上かかっていました。

**結果: CIジョブ全体 14分51秒 → 37秒（テスト実行 866秒 → 9.85秒）**

## 原因

CI上で診断した結果、モデルを1回解くのにlinuxランナーでは13.2秒かかっていました（ローカルmacOSでは0.016秒）。内訳:

- `BlanchardKahnSolver._solve_policy_matrices` は政策関数を `root(method="hybr")` で解き、失敗時は `least_squares(method="dogbox")` ×2回にフォールバックする構造
- hybr/dogboxとも数値微分（有限差分）でヤコビアンを推定しており、linuxのBLAS丸め誤差の違いでhybrが停滞（`success=False`、残差4.8e-3で「進捗なし」と打ち切り）
- そのため**毎回**dogboxフォールバック（70変数の数値微分 × max_nfev=6000 × 2回 ≈ 19秒）に落ちていた
- macOSでは偶然hybrが328評価で収束するため、ローカルでは顕在化しなかった

## 対応

残差 `M(P,R) = A·F·P² + B·F·P + C·F`（`F=[I;R]`）の**解析的ヤコビアン**をKronecker積で実装し、`root` と `least_squares` の両方に渡すようにしました:

- `∂M/∂P = (AF)⊗Pᵀ + (AFP+BF)⊗I`
- `∂M/∂R = (AS)⊗(P²)ᵀ + (BS)⊗Pᵀ + (CS)⊗I`（`S=[0;I]` は選択行列）

数値微分のノイズがなくなることで、プラットフォームに依らずhybrが安定して収束します（CIでの解法時間: 13.21秒 → 0.005秒）。フォールバックに落ちた場合もdogboxが数値微分不要になり大幅に高速化されます。

あわせてCIに `OMP_NUM_THREADS=1` 等を設定し、xdistワーカー×BLASスレッドの過剰購読を予防しています（こちらは予防措置で、本質的な修正は上記ヤコビアン）。

## 検証

- 解析的ヤコビアンと数値微分（3点法）の一致を複数パラメータ・ランダム点で確認（最大差 ~1e-11）
- golden masterテストを含む全454テストがパス（解は不変）
- ローカルのテスト実行も4.4秒 → 2.7秒に短縮
- mypy strict / ruff パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)